### PR TITLE
Thread-pool thread with pyMongo

### DIFF
--- a/stakeout-agent/stakeout_agent/callback_handler/langgraph.py
+++ b/stakeout-agent/stakeout_agent/callback_handler/langgraph.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from uuid import UUID
 
@@ -94,7 +95,8 @@ class AsyncLangGraphMonitorCallback(_MonitorBase, AsyncCallbackHandler):
         tags: list[str] | None = None,  # noqa: ARG002
         **kwargs: Any,
     ) -> None:
-        self._handle_chain_start(serialized, inputs, run_id, parent_run_id, **kwargs)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, lambda: self._handle_chain_start(serialized, inputs, run_id, parent_run_id, **kwargs))
 
     async def on_chain_end(
         self,
@@ -104,7 +106,8 @@ class AsyncLangGraphMonitorCallback(_MonitorBase, AsyncCallbackHandler):
         parent_run_id: UUID | None = None,
         **kwargs: Any,
     ) -> None:
-        self._handle_chain_end(outputs, run_id, parent_run_id, **kwargs)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, lambda: self._handle_chain_end(outputs, run_id, parent_run_id, **kwargs))
 
     async def on_chain_error(
         self,
@@ -114,7 +117,8 @@ class AsyncLangGraphMonitorCallback(_MonitorBase, AsyncCallbackHandler):
         parent_run_id: UUID | None = None,
         **kwargs: Any,
     ) -> None:
-        self._handle_chain_error(error, run_id, parent_run_id, **kwargs)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, lambda: self._handle_chain_error(error, run_id, parent_run_id, **kwargs))
 
     async def on_tool_start(
         self,
@@ -125,10 +129,13 @@ class AsyncLangGraphMonitorCallback(_MonitorBase, AsyncCallbackHandler):
         parent_run_id: UUID | None = None,  # noqa: ARG002
         **kwargs: Any,
     ) -> None:
-        self._handle_tool_start(serialized, input_str, run_id, **kwargs)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, lambda: self._handle_tool_start(serialized, input_str, run_id, **kwargs))
 
     async def on_tool_end(self, output: Any, *, run_id: UUID, **kwargs: Any) -> None:
-        self._handle_tool_end(output, run_id, **kwargs)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, lambda: self._handle_tool_end(output, run_id, **kwargs))
 
     async def on_tool_error(self, error: BaseException, *, run_id: UUID, **kwargs: Any) -> None:
-        self._handle_tool_error(error, run_id, **kwargs)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, lambda: self._handle_tool_error(error, run_id, **kwargs))


### PR DESCRIPTION
# Fix: Blocking I/O in AsyncLangGraphMonitorCallback

## Context

`AsyncLangGraphMonitorCallback` is meant for use with `graph.ainvoke()` / `graph.astream()`. Its six `async def on_*` methods delegate directly to synchronous `_MonitorBase._handle_*` helpers, which call PyMongo's blocking `insert_one()` / `update_one()` on every LangGraph callback. This blocks the event loop on each DB write, defeating the purpose of the async variant.

## Approach: run_in_executor (thread pool offload)

Wrap each synchronous `_handle_*` call in `asyncio.get_running_loop().run_in_executor(None, lambda: ...)` so PyMongo writes execute on a thread-pool thread instead of the event loop thread.

**Why this over Motor migration:**
- Zero new dependencies — MonitorDB stays as-is and remains usable by the sync handler too.
- Minimal blast radius — only `langgraph.py` changes; `db.py`, `base.py`, and `__init__.py` are untouched.
- `run_in_executor` is the standard stdlib pattern for exactly this case.
- Motor would require splitting MonitorDB into sync/async variants and significantly reworking tests.

## Files to change

| File | Change |
|------|--------|
| `stakeout-agent/stakeout_agent/callback_handler/langgraph.py` | Add `import asyncio`; wrap each `_handle_*` call in `run_in_executor` |

## Detailed change

In `AsyncLangGraphMonitorCallback`, every `async def on_*` body changes from:

```python
self._handle_chain_start(serialized, inputs, run_id, parent_run_id, **kwargs)
```

to:

```python
loop = asyncio.get_running_loop()
await loop.run_in_executor(None, lambda: self._handle_chain_start(serialized, inputs, run_id, parent_run_id, **kwargs))
```

Apply the same pattern to all six methods:
- `on_chain_start` → `_handle_chain_start`
- `on_chain_end` → `_handle_chain_end`
- `on_chain_error` → `_handle_chain_error`
- `on_tool_start` → `_handle_tool_start`
- `on_tool_end` → `_handle_tool_end`
- `on_tool_error` → `_handle_tool_error`

The `LangGraphMonitorCallback` (sync) class is unchanged.