### PR TITLE
Hanlde Exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,5 @@ __marimo__/
 /collector
 /dashboard
 docker-compose.yml
+
+CLAUDE.md

--- a/stakeout-agent/stakeout_agent/db.py
+++ b/stakeout-agent/stakeout_agent/db.py
@@ -1,9 +1,13 @@
+import logging
 import os
 import threading
 from datetime import datetime, timezone
 
 from pymongo import DESCENDING, MongoClient
 from pymongo.collection import Collection
+from pymongo.errors import PyMongoError
+
+_log = logging.getLogger(__name__)
 
 
 def _make_client():
@@ -41,26 +45,46 @@ class MonitorDB:
         return self._conn.events
 
     def create_run(self, run_id: str, graph_id: str, thread_id: str) -> None:
-        self.runs.insert_one(
-            {
-                "_id": run_id,
-                "graph_id": graph_id,
-                "thread_id": thread_id,
-                "status": "running",
-                "started_at": datetime.now(timezone.utc),
-                "ended_at": None,
-                "error": None,
-                "metadata": {},
-            }
-        )
+        runs = self.runs
+        try:
+            runs.insert_one(
+                {
+                    "_id": run_id,
+                    "graph_id": graph_id,
+                    "thread_id": thread_id,
+                    "status": "running",
+                    "started_at": datetime.now(timezone.utc),
+                    "ended_at": None,
+                    "error": None,
+                    "metadata": {},
+                }
+            )
+        except PyMongoError as exc:
+            _log.error("create_run %s failed: %s", run_id, exc)
 
     def complete_run(self, run_id: str) -> None:
-        self.runs.update_one({"_id": run_id}, {"$set": {"status": "completed", "ended_at": datetime.now(timezone.utc)}})
+        runs = self.runs
+        try:
+            result = runs.update_one(
+                {"_id": run_id}, {"$set": {"status": "completed", "ended_at": datetime.now(timezone.utc)}}
+            )
+        except PyMongoError as exc:
+            _log.error("complete_run %s failed: %s", run_id, exc)
+            return
+        if result.matched_count == 0:
+            _log.warning("complete_run: no run found with id %s", run_id)
 
     def fail_run(self, run_id: str, error: str) -> None:
-        self.runs.update_one(
-            {"_id": run_id}, {"$set": {"status": "failed", "ended_at": datetime.now(timezone.utc), "error": error}}
-        )
+        runs = self.runs
+        try:
+            result = runs.update_one(
+                {"_id": run_id}, {"$set": {"status": "failed", "ended_at": datetime.now(timezone.utc), "error": error}}
+            )
+        except PyMongoError as exc:
+            _log.error("fail_run %s failed: %s", run_id, exc)
+            return
+        if result.matched_count == 0:
+            _log.warning("fail_run: no run found with id %s", run_id)
 
     def insert_event(
         self,
@@ -72,15 +96,19 @@ class MonitorDB:
         payload: dict | None = None,
         error: str | None = None,
     ) -> None:
-        self.events.insert_one(
-            {
-                "run_id": run_id,
-                "graph_id": graph_id,
-                "event_type": event_type,
-                "node_name": node_name,
-                "timestamp": datetime.now(timezone.utc),
-                "latency_ms": latency_ms,
-                "payload": payload or {},
-                "error": error,
-            }
-        )
+        events = self.events
+        try:
+            events.insert_one(
+                {
+                    "run_id": run_id,
+                    "graph_id": graph_id,
+                    "event_type": event_type,
+                    "node_name": node_name,
+                    "timestamp": datetime.now(timezone.utc),
+                    "latency_ms": latency_ms,
+                    "payload": payload or {},
+                    "error": error,
+                }
+            )
+        except PyMongoError as exc:
+            _log.error("insert_event for run %s failed: %s", run_id, exc)

--- a/stakeout-agent/tests/test_db.py
+++ b/stakeout-agent/tests/test_db.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pymongo.errors import ConnectionFailure
+from pymongo.errors import ConnectionFailure, OperationFailure
 
 from stakeout_agent.db import MonitorDB
 
@@ -38,6 +38,14 @@ def _patched_monitor(mock_db):
 
 
 class TestCreateRun:
+    def test_write_error_is_logged_not_raised(self, caplog):
+        mock_db, mock_runs, _ = _make_mock_db()
+        mock_runs.insert_one.side_effect = OperationFailure("disk full")
+        with _patched_monitor(mock_db) as monitor:
+            monitor.create_run("run-1", "g", "t")  # must not raise
+
+        assert any("create_run" in r.message and "run-1" in r.message for r in caplog.records)
+
     def test_inserts_correct_document(self):
         mock_db, mock_runs, _ = _make_mock_db()
         with _patched_monitor(mock_db) as monitor:
@@ -72,6 +80,22 @@ class TestCompleteRun:
         assert update["$set"]["status"] == "completed"
         assert isinstance(update["$set"]["ended_at"], datetime)
 
+    def test_write_error_is_logged_not_raised(self, caplog):
+        mock_db, mock_runs, _ = _make_mock_db()
+        mock_runs.update_one.side_effect = OperationFailure("timeout")
+        with _patched_monitor(mock_db) as monitor:
+            monitor.complete_run("run-1")  # must not raise
+
+        assert any("complete_run" in r.message and "run-1" in r.message for r in caplog.records)
+
+    def test_missing_run_id_logs_warning(self, caplog):
+        mock_db, mock_runs, _ = _make_mock_db()
+        mock_runs.update_one.return_value.matched_count = 0
+        with _patched_monitor(mock_db) as monitor:
+            monitor.complete_run("nonexistent")  # must not raise
+
+        assert any("nonexistent" in r.message for r in caplog.records)
+
     def test_missing_run_id_does_not_raise(self):
         mock_db, mock_runs, _ = _make_mock_db()
         mock_runs.update_one.return_value.matched_count = 0
@@ -95,6 +119,22 @@ class TestFailRun:
         assert update["$set"]["status"] == "failed"
         assert update["$set"]["error"] == "boom"
         assert isinstance(update["$set"]["ended_at"], datetime)
+
+    def test_write_error_is_logged_not_raised(self, caplog):
+        mock_db, mock_runs, _ = _make_mock_db()
+        mock_runs.update_one.side_effect = OperationFailure("timeout")
+        with _patched_monitor(mock_db) as monitor:
+            monitor.fail_run("run-1", "boom")  # must not raise
+
+        assert any("fail_run" in r.message and "run-1" in r.message for r in caplog.records)
+
+    def test_missing_run_id_logs_warning(self, caplog):
+        mock_db, mock_runs, _ = _make_mock_db()
+        mock_runs.update_one.return_value.matched_count = 0
+        with _patched_monitor(mock_db) as monitor:
+            monitor.fail_run("nonexistent", "error")  # must not raise
+
+        assert any("nonexistent" in r.message for r in caplog.records)
 
     def test_missing_run_id_does_not_raise(self):
         mock_db, mock_runs, _ = _make_mock_db()
@@ -132,6 +172,14 @@ class TestInsertEvent:
         assert doc["latency_ms"] == 12.5
         assert doc["payload"] == {"x": 1}
         assert doc["error"] is None
+
+    def test_write_error_is_logged_not_raised(self, caplog):
+        mock_db, _, mock_events = _make_mock_db()
+        mock_events.insert_one.side_effect = OperationFailure("disk full")
+        with _patched_monitor(mock_db) as monitor:
+            monitor.insert_event(run_id="run-1", graph_id="g", event_type="e", node_name="n")  # must not raise
+
+        assert any("insert_event" in r.message and "run-1" in r.message for r in caplog.records)
 
     def test_payload_defaults_to_empty_dict(self):
         mock_db, _, mock_events = _make_mock_db()


### PR DESCRIPTION
**db.py**
Added logging, PyMongoError imports and a module-level _log logger
In each write method, the collection property access (self.runs / self.events) is now outside the try block — so a ConnectionFailure during lazy initialization still propagates (preserving the existing test behaviour)
The insert_one / update_one calls are wrapped in try/except PyMongoError which logs an error and returns instead of crashing the callback
complete_run and fail_run now check result.matched_count == 0 and log a warning when the run_id wasn't found

**test_db.py**
Added test_write_error_is_logged_not_raised to all four method test classes (uses OperationFailure to simulate a mid-operation MongoDB error)
Added test_missing_run_id_logs_warning to TestCompleteRun and TestFailRun to assert the warning is actually emitted