### PR TITLE
Handling the unknown values

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ monitor = AsyncLangGraphMonitorCallback(graph_id="my_graph", thread_id="thread_1
 result = await graph.ainvoke(inputs, config={"callbacks": [monitor]})
 ```
 
+## Try the example
+
+A self-contained example graph is included to verify everything is wired up correctly.
+
+Start MongoDB, then run:
+
+```bash
+docker compose up -d mongo
+cd stakeout-agent
+uv run python examples/dummy_app.py
+```
+
+It runs a three-node graph (with a tool call), then prints the `runs` and `events` documents written to MongoDB so you can confirm monitoring is working before integrating into your own application.
+
 ## Configuration
 
 | Environment variable | Default | Description |
@@ -73,6 +87,22 @@ One document per graph invocation.
 
 One document per node start/end, tool call, or error within a run.
 
+Start events:
+
+```json
+{
+  "run_id": "<run_id>",
+  "graph_id": "my_graph",
+  "event_type": "node_start",
+  "node_name": "agent",
+  "timestamp": "2026-04-25T10:00:02Z",
+  "payload": {"inputs": "..."},
+  "error": null
+}
+```
+
+End events include a `latency_ms` field measuring execution time:
+
 ```json
 {
   "run_id": "<run_id>",
@@ -81,18 +111,18 @@ One document per node start/end, tool call, or error within a run.
   "node_name": "agent",
   "timestamp": "2026-04-25T10:00:03Z",
   "latency_ms": 1240.5,
-  "payload": {},
+  "payload": {"outputs": "..."},
   "error": null
 }
 ```
 
-| `event_type` | When |
-|---|---|
-| `node_start` | A graph node begins execution |
-| `node_end` | A graph node completes |
-| `tool_call` | A tool is invoked |
-| `tool_result` | A tool returns a result |
-| `error` | A node or tool raises an exception |
+| `event_type` | When | `latency_ms` |
+|---|---|---|
+| `node_start` | A graph node begins execution | absent |
+| `node_end` | A graph node completes | present |
+| `tool_call` | A tool is invoked | absent |
+| `tool_result` | A tool returns a result | present |
+| `error` | A node or tool raises an exception | present |
 
 ## Error handling
 

--- a/stakeout-agent/examples/dummy_app.py
+++ b/stakeout-agent/examples/dummy_app.py
@@ -1,0 +1,115 @@
+"""
+Dummy LangGraph application to manually verify stakeout-agent monitoring.
+
+Run MongoDB first:
+    docker compose up -d mongo
+
+Then run this script:
+    uv run python examples/dummy_app.py
+
+It will print every document written to the `runs` and `events` collections.
+"""
+
+import json
+import logging
+import time
+from typing import TypedDict
+
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+from langgraph.graph import END, START, StateGraph
+
+from stakeout_agent import LangGraphMonitorCallback
+from stakeout_agent.db import MonitorDB
+
+logging.basicConfig(level=logging.DEBUG, format="%(levelname)s %(name)s — %(message)s")
+
+
+# ---------------------------------------------------------------------------
+# A trivial tool (no LLM required)
+# ---------------------------------------------------------------------------
+
+@tool
+def multiply(a: int, b: int) -> int:
+    """Multiply two integers."""
+    return a * b
+
+
+# ---------------------------------------------------------------------------
+# Graph state
+# ---------------------------------------------------------------------------
+
+class State(TypedDict):
+    value: int
+    result: int
+
+
+# ---------------------------------------------------------------------------
+# Nodes
+# ---------------------------------------------------------------------------
+
+def double_node(state: State) -> dict:
+    return {"value": state["value"] * 2}
+
+
+def multiply_node(state: State, config: RunnableConfig) -> dict:
+    # Invoking a @tool with the propagated config fires tool_call / tool_result callbacks.
+    product = multiply.invoke({"a": state["value"], "b": 3}, config=config)
+    return {"result": product}
+
+
+def summary_node(state: State) -> dict:
+    print(f"\n[graph] input doubled to {state['value']}, then multiplied by 3 → {state['result']}")
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Build graph
+# ---------------------------------------------------------------------------
+
+def build_graph():
+    g = StateGraph(State)
+    g.add_node("double", double_node)
+    g.add_node("multiply", multiply_node)
+    g.add_node("summary", summary_node)
+    g.add_edge(START, "double")
+    g.add_edge("double", "multiply")
+    g.add_edge("multiply", "summary")
+    g.add_edge("summary", END)
+    return g.compile()
+
+
+# ---------------------------------------------------------------------------
+# Run and inspect
+# ---------------------------------------------------------------------------
+
+def main():
+    graph = build_graph()
+
+    monitor = LangGraphMonitorCallback(graph_id="dummy_graph", thread_id="thread_001")
+
+    print("\n--- Running graph ---")
+    graph.invoke({"value": 5}, config={"callbacks": [monitor]})
+
+    # Give a moment for any async flushing (not needed for sync, but good practice)
+    time.sleep(0.1)
+
+    print("\n--- Inspecting MongoDB ---")
+    db = MonitorDB()
+
+    run = db.runs.find_one({"graph_id": "dummy_graph"}, sort=[("started_at", -1)])
+    if run is None:
+        print("ERROR: no run document found — is MongoDB running?")
+        return
+
+    print(f"\nrun document:\n{json.dumps(run, default=str, indent=2)}")
+
+    events = list(db.events.find({"run_id": run["_id"]}).sort("timestamp", 1))
+    print(f"\nevents ({len(events)} total):")
+    for ev in events:
+        latency = f"{ev['latency_ms']} ms" if "latency_ms" in ev else "-"
+        print(f"  [{ev['event_type']:12s}] node={ev['node_name']:15s} latency={latency}")
+
+
+if __name__ == "__main__":
+    main()

--- a/stakeout-agent/stakeout_agent/callback_handler/base.py
+++ b/stakeout-agent/stakeout_agent/callback_handler/base.py
@@ -21,6 +21,7 @@ class _MonitorBase:
 
         self._run_id: str | None = None
         self._node_start_times: dict[str, float] = {}
+        self._node_names: dict[str, str] = {}
         self._tool_start_times: dict[str, float] = {}
 
     def _handle_chain_start(
@@ -39,6 +40,7 @@ class _MonitorBase:
         else:
             node_name = self._extract_name(serialized, kwargs)
             self._node_start_times[run_id_str] = time.monotonic()
+            self._node_names[run_id_str] = node_name
             self._log.debug("node_start node=%s run_id=%s", node_name, self._run_id)
             self.db.insert_event(
                 run_id=self._run_id,
@@ -61,7 +63,7 @@ class _MonitorBase:
             self.db.complete_run(self._run_id)
         else:
             latency = self._pop_latency(self._node_start_times, run_id_str)
-            node_name = kwargs.get("name", "unknown")
+            node_name = self._node_names.pop(run_id_str, "unknown")
             self._log.debug("node_end node=%s latency_ms=%s run_id=%s", node_name, latency, self._run_id)
             self.db.insert_event(
                 run_id=self._run_id,
@@ -86,7 +88,7 @@ class _MonitorBase:
             self.db.fail_run(self._run_id, error_str)
         else:
             latency = self._pop_latency(self._node_start_times, run_id_str)
-            node_name = kwargs.get("name", "unknown")
+            node_name = self._node_names.pop(run_id_str, "unknown")
             self._log.warning("node error node=%s run_id=%s error=%s", node_name, self._run_id, error_str)
             self.db.insert_event(
                 run_id=self._run_id,

--- a/stakeout-agent/stakeout_agent/db.py
+++ b/stakeout-agent/stakeout_agent/db.py
@@ -104,19 +104,19 @@ class MonitorDB:
         error: str | None = None,
     ) -> None:
         events = self.events
+        doc: dict = {
+            "run_id": run_id,
+            "graph_id": graph_id,
+            "event_type": event_type,
+            "node_name": node_name,
+            "timestamp": datetime.now(timezone.utc),
+            "payload": payload or {},
+            "error": error,
+        }
+        if latency_ms is not None:
+            doc["latency_ms"] = latency_ms
         try:
-            events.insert_one(
-                {
-                    "run_id": run_id,
-                    "graph_id": graph_id,
-                    "event_type": event_type,
-                    "node_name": node_name,
-                    "timestamp": datetime.now(timezone.utc),
-                    "latency_ms": latency_ms,
-                    "payload": payload or {},
-                    "error": error,
-                }
-            )
+            events.insert_one(doc)
         except PyMongoError as exc:
             _log.error("insert_event for run %s failed: %s", run_id, exc)
             return


### PR DESCRIPTION
`callback_handler/base.py`
Added _node_names dict to store node name at chain_start, so node_end and chain_error resolve the correct name instead of falling back to "unknown"

`db.py`
insert_event no longer stores latency_ms: null — the field is omitted entirely for start events

`README.md`
Updated events collection docs to show start vs end event shapes and a table indicating which event types carry latency_ms
Added "Try the example" section pointing to examples/dummy_app.py

`examples/dummy_app.py` __(new file)__

Three-node LangGraph (no LLM) with a tool call, wired up with LangGraphMonitorCallback, that prints what was written to MongoDB after each run