### PR TITLE
fix(callback): guard _extract_name against empty "id" list (#6)

### DIFF
--- a/stakeout-agent/stakeout_agent/callback_handler/base.py
+++ b/stakeout-agent/stakeout_agent/callback_handler/base.py
@@ -479,7 +479,8 @@ class _MonitorBase:
     @staticmethod
     def _extract_name(serialized: dict | None, kwargs: dict) -> str:
         if serialized:
-            return serialized.get("name") or serialized.get("id", ["unknown"])[-1] or kwargs.get("name", "unknown")
+            ids = serialized.get("id") or ["unknown"]
+            return serialized.get("name") or ids[-1] or kwargs.get("name", "unknown")
         return kwargs.get("name", "unknown")
 
     @staticmethod

--- a/stakeout-agent/tests/test_callback_handler.py
+++ b/stakeout-agent/tests/test_callback_handler.py
@@ -37,6 +37,10 @@ class TestExtractName:
     def test_unknown_when_nothing_available(self):
         assert _MonitorBase._extract_name(None, {}) == "unknown"
 
+    def test_empty_id_list_falls_back_to_unknown(self):
+        # Regression: empty "id" list previously raised IndexError on [-1].
+        assert _MonitorBase._extract_name({"id": []}, {}) == "unknown"
+
 
 class TestPopLatency:
     def test_returns_positive_milliseconds(self):


### PR DESCRIPTION
Closes #6.

`serialized.get("id", ["unknown"])[-1]` only used the default when the `"id"` key was absent. If a caller passed `{"id": []}`, the empty list propagated and `[-1]` raised `IndexError`. Switched to `or` so empty lists also fall back to `["unknown"]`.

Regression test: `tests/test_callback_handler.py::TestExtractName::test_empty_id_list_falls_back_to_unknown`.