### PR TITLE
Closes #63

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ stakeout-agent hooks into your framework's event system. It records a `run` docu
 | Prompt & response capture | **Yes** — per node, opt-out, truncation supported |
 | Non-blocking writes | **Yes** — opt-in `BufferedWriter` keeps DB I/O off the LLM hot path |
 | Sliding-window alerting | **Yes** — error rate, P95/P99 latency, cost; webhook to Slack, PagerDuty, etc. |
+| Data retention / TTL | **Yes** — configurable per environment or graph; MongoDB TTL index, Postgres sweep CLI |
 | MCP server | **Yes** — agents query their own run history at runtime via standard MCP tools |
 | Frameworks | **LangGraph + CrewAI** |
 | Backends | **MongoDB + PostgreSQL + OpenTelemetry** |
@@ -457,6 +458,9 @@ Each example runs a two-agent crew (Researcher + Writer) with a `MultiplyTool`, 
 | `OTEL_EXPORTER_OTLP_HEADERS` | — | Headers for the OTLP exporter (e.g. auth tokens) |
 | `OTEL_SERVICE_NAME` | `stakeout-agent` | Service name attached to all spans |
 | `STAKEOUT_DLQ_PATH` | `stakeout_dlq.jsonl` | Path for the `BufferedWriter` dead-letter queue file |
+| `STAKEOUT_RETENTION_DEFAULT_DAYS` | — | Default TTL in days for all runs; unset disables retention |
+| `STAKEOUT_RETENTION_DEV_DAYS` | — | TTL override for runs tagged `environment="dev"` |
+| `STAKEOUT_RETENTION_STAGING_DAYS` | — | TTL override for runs tagged `environment="staging"` |
 
 ### PostgreSQL
 
@@ -742,6 +746,88 @@ Webhook delivery failures are logged at `WARNING` and never raised into the call
 
 ---
 
+## Data retention
+
+`RetentionPolicy` sets a TTL on every run at write time, so old data is deleted automatically — no cron job required for MongoDB, and a single CLI sweep handles PostgreSQL.
+
+### Why
+
+Enterprises operating under GDPR, CCPA, or internal data governance policies need to demonstrate that data is not held beyond a stated period. Without retention, stakeout accumulates data indefinitely. Dev and staging environments also generate high volumes of low-value data that should expire far sooner than production.
+
+### Configure via env vars
+
+```bash
+STAKEOUT_RETENTION_DEFAULT_DAYS=90    # production
+STAKEOUT_RETENTION_DEV_DAYS=7         # expires dev runs after 7 days
+STAKEOUT_RETENTION_STAGING_DAYS=14    # expires staging runs after 14 days
+```
+
+### Configure programmatically
+
+```python
+from stakeout_agent import MongoMonitorDB, RetentionPolicy
+
+policy = RetentionPolicy(
+    default_days=90,
+    overrides={
+        "environment:dev": 7,
+        "environment:staging": 14,
+        "graph:experimental-agent": 30,
+    },
+)
+
+db = MongoMonitorDB(retention=policy)
+```
+
+Pass `retention=policy` to `MongoMonitorDB` or `PostgresMonitorDB`. Setting `retention=None` (the default) preserves the original behaviour — data is never automatically deleted.
+
+Override keys are matched in priority order: `environment:<name>` first, then `graph:<id>`, then `default_days`.
+
+### Tag runs with an environment
+
+Pass `environment=` to the callback constructor so the policy can resolve the correct TTL:
+
+```python
+monitor = LangGraphMonitorCallback(
+    graph_id="my_graph",
+    thread_id="thread_123",
+    db=db,
+    environment="staging",
+)
+```
+
+### How it works per backend
+
+| Backend | Mechanism |
+|---|---|
+| **MongoDB** | A TTL index on `runs.expires_at` and `events.expires_at` is created on first connect (`expireAfterSeconds=0`). MongoDB's background reaper deletes expired documents automatically — no background thread or cron job needed. |
+| **PostgreSQL** | `expires_at` is written on insert (migration `0005` adds the column). Run `stakeout retention apply` periodically (e.g. via cron or `pg_cron`) to delete expired rows. |
+
+### PostgreSQL: sweep expired rows
+
+```bash
+POSTGRES_URI=postgresql://user:pass@localhost/stakeout stakeout retention apply
+# → retention apply: deleted 1 042 run(s) and 9 381 event(s).
+```
+
+Add this to a cron entry or `pg_cron` job to automate it.
+
+### Backfill existing data
+
+Existing rows written before a retention policy was configured have no `expires_at`. Use `backfill` to set one retrospectively:
+
+```bash
+# PostgreSQL
+POSTGRES_URI=... stakeout retention backfill --days 90
+
+# MongoDB
+MONGO_URI=... stakeout retention backfill --days 90
+```
+
+Both commands update only rows where `expires_at` is currently unset, so they are safe to run multiple times.
+
+---
+
 ## MCP server
 
 The `stakeout-agent[mcp]` extra ships a [Model Context Protocol](https://modelcontextprotocol.io) server that exposes your run history as callable tools and browsable resources. Any MCP-aware agent — ChatGPT, Claude, a LangGraph agent with MCP tool nodes, AutoGen — can call these tools as part of its reasoning loop to detect repeated failures, surface cost metrics, or adjust its strategy based on what went wrong before.
@@ -983,6 +1069,7 @@ Select the `stakeout-agent` service (or whatever `OTEL_SERVICE_NAME` is set to) 
 - [x] Non-blocking async buffered writes (`BufferedWriter` — in-memory queue, exponential-backoff retry, dead-letter queue)
 - [x] Sliding-window alerting (`AlertManager` — error rate, P95/P99 latency, cost; webhook to Slack, PagerDuty, or any HTTP endpoint; per-rule cooldown)
 - [x] [Dedicated UI dashboard](https://github.com/KyriakosFrang/stakeout-dashboard) (Run History, Node Performance, Run Inspector, Thread Deep Dive)
+- [x] Configurable data retention / TTL (`RetentionPolicy` — per environment or graph; MongoDB TTL index; Postgres `stakeout retention apply` sweep)
 - [ ] Additional agentic frameworks (PydanticAI, SemanticKernel, AutoGen etc.)
 - [ ] Additional storage backends (SQLite, Redis, …)
 

--- a/stakeout-agent/README.md
+++ b/stakeout-agent/README.md
@@ -101,6 +101,7 @@ stakeout-agent hooks into your framework's event system. It records a `run` docu
 | Prompt & response capture | **Yes** — per node, opt-out, truncation supported |
 | Non-blocking writes | **Yes** — opt-in `BufferedWriter` keeps DB I/O off the LLM hot path |
 | Sliding-window alerting | **Yes** — error rate, P95/P99 latency, cost; webhook to Slack, PagerDuty, etc. |
+| Data retention / TTL | **Yes** — configurable per environment or graph; MongoDB TTL index, Postgres sweep CLI |
 | MCP server | **Yes** — agents query their own run history at runtime via standard MCP tools |
 | Frameworks | **LangGraph + CrewAI** |
 | Backends | **MongoDB + PostgreSQL + OpenTelemetry** |
@@ -457,6 +458,9 @@ Each example runs a two-agent crew (Researcher + Writer) with a `MultiplyTool`, 
 | `OTEL_EXPORTER_OTLP_HEADERS` | — | Headers for the OTLP exporter (e.g. auth tokens) |
 | `OTEL_SERVICE_NAME` | `stakeout-agent` | Service name attached to all spans |
 | `STAKEOUT_DLQ_PATH` | `stakeout_dlq.jsonl` | Path for the `BufferedWriter` dead-letter queue file |
+| `STAKEOUT_RETENTION_DEFAULT_DAYS` | — | Default TTL in days for all runs; unset disables retention |
+| `STAKEOUT_RETENTION_DEV_DAYS` | — | TTL override for runs tagged `environment="dev"` |
+| `STAKEOUT_RETENTION_STAGING_DAYS` | — | TTL override for runs tagged `environment="staging"` |
 
 ### PostgreSQL
 
@@ -742,6 +746,88 @@ Webhook delivery failures are logged at `WARNING` and never raised into the call
 
 ---
 
+## Data retention
+
+`RetentionPolicy` sets a TTL on every run at write time, so old data is deleted automatically — no cron job required for MongoDB, and a single CLI sweep handles PostgreSQL.
+
+### Why
+
+Enterprises operating under GDPR, CCPA, or internal data governance policies need to demonstrate that data is not held beyond a stated period. Without retention, stakeout accumulates data indefinitely. Dev and staging environments also generate high volumes of low-value data that should expire far sooner than production.
+
+### Configure via env vars
+
+```bash
+STAKEOUT_RETENTION_DEFAULT_DAYS=90    # production
+STAKEOUT_RETENTION_DEV_DAYS=7         # expires dev runs after 7 days
+STAKEOUT_RETENTION_STAGING_DAYS=14    # expires staging runs after 14 days
+```
+
+### Configure programmatically
+
+```python
+from stakeout_agent import MongoMonitorDB, RetentionPolicy
+
+policy = RetentionPolicy(
+    default_days=90,
+    overrides={
+        "environment:dev": 7,
+        "environment:staging": 14,
+        "graph:experimental-agent": 30,
+    },
+)
+
+db = MongoMonitorDB(retention=policy)
+```
+
+Pass `retention=policy` to `MongoMonitorDB` or `PostgresMonitorDB`. Setting `retention=None` (the default) preserves the original behaviour — data is never automatically deleted.
+
+Override keys are matched in priority order: `environment:<name>` first, then `graph:<id>`, then `default_days`.
+
+### Tag runs with an environment
+
+Pass `environment=` to the callback constructor so the policy can resolve the correct TTL:
+
+```python
+monitor = LangGraphMonitorCallback(
+    graph_id="my_graph",
+    thread_id="thread_123",
+    db=db,
+    environment="staging",
+)
+```
+
+### How it works per backend
+
+| Backend | Mechanism |
+|---|---|
+| **MongoDB** | A TTL index on `runs.expires_at` and `events.expires_at` is created on first connect (`expireAfterSeconds=0`). MongoDB's background reaper deletes expired documents automatically — no background thread or cron job needed. |
+| **PostgreSQL** | `expires_at` is written on insert (migration `0005` adds the column). Run `stakeout retention apply` periodically (e.g. via cron or `pg_cron`) to delete expired rows. |
+
+### PostgreSQL: sweep expired rows
+
+```bash
+POSTGRES_URI=postgresql://user:pass@localhost/stakeout stakeout retention apply
+# → retention apply: deleted 1 042 run(s) and 9 381 event(s).
+```
+
+Add this to a cron entry or `pg_cron` job to automate it.
+
+### Backfill existing data
+
+Existing rows written before a retention policy was configured have no `expires_at`. Use `backfill` to set one retrospectively:
+
+```bash
+# PostgreSQL
+POSTGRES_URI=... stakeout retention backfill --days 90
+
+# MongoDB
+MONGO_URI=... stakeout retention backfill --days 90
+```
+
+Both commands update only rows where `expires_at` is currently unset, so they are safe to run multiple times.
+
+---
+
 ## MCP server
 
 The `stakeout-agent[mcp]` extra ships a [Model Context Protocol](https://modelcontextprotocol.io) server that exposes your run history as callable tools and browsable resources. Any MCP-aware agent — ChatGPT, Claude, a LangGraph agent with MCP tool nodes, AutoGen — can call these tools as part of its reasoning loop to detect repeated failures, surface cost metrics, or adjust its strategy based on what went wrong before.
@@ -983,6 +1069,7 @@ Select the `stakeout-agent` service (or whatever `OTEL_SERVICE_NAME` is set to) 
 - [x] Non-blocking async buffered writes (`BufferedWriter` — in-memory queue, exponential-backoff retry, dead-letter queue)
 - [x] Sliding-window alerting (`AlertManager` — error rate, P95/P99 latency, cost; webhook to Slack, PagerDuty, or any HTTP endpoint; per-rule cooldown)
 - [x] [Dedicated UI dashboard](https://github.com/KyriakosFrang/stakeout-dashboard) (Run History, Node Performance, Run Inspector, Thread Deep Dive)
+- [x] Configurable data retention / TTL (`RetentionPolicy` — per environment or graph; MongoDB TTL index; Postgres `stakeout retention apply` sweep)
 - [ ] Additional agentic frameworks (PydanticAI, SemanticKernel, AutoGen etc.)
 - [ ] Additional storage backends (SQLite, Redis, …)
 

--- a/stakeout-agent/stakeout_agent/__init__.py
+++ b/stakeout-agent/stakeout_agent/__init__.py
@@ -26,6 +26,7 @@ except ImportError:
 
 from stakeout_agent.alerts import AlertManager, Rule
 from stakeout_agent.pricing import ModelPricing, PricingMap
+from stakeout_agent.retention import RetentionPolicy
 from stakeout_agent.writer import BufferedWriter
 
 __all__ = [
@@ -40,4 +41,5 @@ __all__ = [
     "BufferedWriter",
     "AlertManager",
     "Rule",
+    "RetentionPolicy",
 ]

--- a/stakeout-agent/stakeout_agent/backends/base.py
+++ b/stakeout-agent/stakeout_agent/backends/base.py
@@ -50,6 +50,7 @@ class AbstractMonitorDB(ABC):
         run_inputs: str | None = None,
         parent_run_id: str | None = None,
         prompt_version: str | None = None,
+        environment: str | None = None,
     ) -> None: ...
 
     @abstractmethod
@@ -65,6 +66,14 @@ class AbstractMonitorDB(ABC):
 
     @abstractmethod
     def fail_run(self, run_id: str, error: str) -> None: ...
+
+    @abstractmethod
+    def prune_runs(self, older_than_days: int) -> int:
+        """Delete runs (and their events) whose started_at is older than *older_than_days* days.
+
+        Returns the number of runs deleted.
+        """
+        ...
 
     @abstractmethod
     def insert_event(

--- a/stakeout-agent/stakeout_agent/backends/migrations/versions/0005_add_expires_at.py
+++ b/stakeout-agent/stakeout_agent/backends/migrations/versions/0005_add_expires_at.py
@@ -1,0 +1,32 @@
+"""Add expires_at column to runs and events for TTL-based retention.
+
+Revision ID: 0005
+Revises: 0004
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE runs   ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ")
+    op.execute("ALTER TABLE events ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_runs_expires_at   ON runs(expires_at)   WHERE expires_at IS NOT NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_events_expires_at ON events(expires_at) WHERE expires_at IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_runs_expires_at")
+    op.execute("DROP INDEX IF EXISTS idx_events_expires_at")
+    op.execute("ALTER TABLE runs   DROP COLUMN IF EXISTS expires_at")
+    op.execute("ALTER TABLE events DROP COLUMN IF EXISTS expires_at")

--- a/stakeout-agent/stakeout_agent/backends/mongodb.py
+++ b/stakeout-agent/stakeout_agent/backends/mongodb.py
@@ -3,7 +3,7 @@ import os
 import statistics
 import threading
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 try:
     from pymongo import DESCENDING, MongoClient
@@ -22,6 +22,7 @@ except ImportError:
 
 
 from stakeout_agent.backends.base import AbstractMonitorDB, AbstractQueryDB
+from stakeout_agent.retention import RetentionPolicy
 
 _log = logging.getLogger(__name__)
 
@@ -126,9 +127,11 @@ def _percentile(values: list[float], p: int) -> float | None:
 
 
 class MongoMonitorDB(AbstractMonitorDB, AbstractQueryDB):
-    def __init__(self):
+    def __init__(self, retention: RetentionPolicy | None = None):
         self._db = None
         self._lock = threading.Lock()
+        self._retention = retention
+        self._run_expires: dict[str, datetime] = {}
 
     @property
     def _conn(self):
@@ -136,6 +139,9 @@ class MongoMonitorDB(AbstractMonitorDB, AbstractQueryDB):
             with self._lock:
                 if self._db is None:
                     self._db = _make_client()
+                    if self._retention is not None:
+                        self._db.runs.create_index("expires_at", expireAfterSeconds=0, sparse=True)
+                        self._db.events.create_index("expires_at", expireAfterSeconds=0, sparse=True)
         return self._db
 
     @property
@@ -182,7 +188,12 @@ class MongoMonitorDB(AbstractMonitorDB, AbstractQueryDB):
         run_inputs: str | None = None,
         parent_run_id: str | None = None,
         prompt_version: str | None = None,
+        environment: str | None = None,
     ) -> None:
+        exp_at = self._retention.expires_at(graph_id=graph_id, environment=environment) if self._retention else None
+        if exp_at is not None:
+            self._run_expires[run_id] = exp_at
+
         def _op():
             doc: dict = {
                 "_id": run_id,
@@ -200,6 +211,8 @@ class MongoMonitorDB(AbstractMonitorDB, AbstractQueryDB):
                 doc["parent_run_id"] = parent_run_id
             if prompt_version is not None:
                 doc["prompt_version"] = prompt_version
+            if exp_at is not None:
+                doc["expires_at"] = exp_at
             self._conn.runs.insert_one(doc)
             _log.debug("create_run inserted run_id=%s graph_id=%s", run_id, graph_id)
 
@@ -214,6 +227,8 @@ class MongoMonitorDB(AbstractMonitorDB, AbstractQueryDB):
         total_cache_read_tokens: int | None = None,
         total_cache_creation_tokens: int | None = None,
     ) -> None:
+        self._run_expires.pop(run_id, None)
+
         def _op():
             update: dict = {"status": "completed", "ended_at": datetime.now(timezone.utc)}
             if total_input_tokens is not None:
@@ -235,6 +250,8 @@ class MongoMonitorDB(AbstractMonitorDB, AbstractQueryDB):
         self._run_with_retry(f"complete_run {run_id}", _op)
 
     def fail_run(self, run_id: str, error: str) -> None:
+        self._run_expires.pop(run_id, None)
+
         def _op():
             result = self._conn.runs.update_one(
                 {"_id": run_id},
@@ -246,6 +263,22 @@ class MongoMonitorDB(AbstractMonitorDB, AbstractQueryDB):
                 _log.debug("fail_run run_id=%s", run_id)
 
         self._run_with_retry(f"fail_run {run_id}", _op)
+
+    def prune_runs(self, older_than_days: int) -> int:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=older_than_days)
+        deleted = 0
+
+        def _op():
+            nonlocal deleted
+            run_ids = self._conn.runs.distinct("_id", {"started_at": {"$lt": cutoff}})
+            if run_ids:
+                self._conn.events.delete_many({"run_id": {"$in": run_ids}})
+            result = self._conn.runs.delete_many({"started_at": {"$lt": cutoff}})
+            deleted = result.deleted_count
+            _log.info("prune_runs deleted %d runs older than %d days", deleted, older_than_days)
+
+        self._run_with_retry(f"prune_runs older_than_days={older_than_days}", _op)
+        return deleted
 
     def insert_event(
         self,
@@ -265,6 +298,8 @@ class MongoMonitorDB(AbstractMonitorDB, AbstractQueryDB):
         cache_read_tokens: int | None = None,
         cache_creation_tokens: int | None = None,
     ) -> None:
+        exp_at = self._run_expires.get(run_id)
+
         def _op():
             doc: dict = {
                 "run_id": run_id,
@@ -293,6 +328,8 @@ class MongoMonitorDB(AbstractMonitorDB, AbstractQueryDB):
                 doc["cache_read_tokens"] = cache_read_tokens
             if cache_creation_tokens is not None:
                 doc["cache_creation_tokens"] = cache_creation_tokens
+            if exp_at is not None:
+                doc["expires_at"] = exp_at
             self._conn.events.insert_one(doc)
             _log.debug("insert_event event_type=%s node=%s run_id=%s", event_type, node_name, run_id)
 

--- a/stakeout-agent/stakeout_agent/backends/otel.py
+++ b/stakeout-agent/stakeout_agent/backends/otel.py
@@ -77,6 +77,7 @@ class OTELMonitorDB(AbstractMonitorDB):
         run_inputs: str | None = None,
         parent_run_id: str | None = None,
         prompt_version: str | None = None,
+        environment: str | None = None,
     ) -> None:
         attrs: dict[str, str] = {
             "stakeout.run_id": run_id,
@@ -126,6 +127,9 @@ class OTELMonitorDB(AbstractMonitorDB):
         span.set_status(StatusCode.OK)
         span.end()
         _logger.debug("otel: root span ended run_id=%s", run_id)
+
+    def prune_runs(self, older_than_days: int) -> int:
+        return 0
 
     def fail_run(self, run_id: str, error: str) -> None:
         from opentelemetry.trace import StatusCode

--- a/stakeout-agent/stakeout_agent/backends/postgres.py
+++ b/stakeout-agent/stakeout_agent/backends/postgres.py
@@ -6,7 +6,7 @@ import os
 import statistics
 import threading
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from stakeout_agent.backends.base import AbstractMonitorDB, AbstractQueryDB
 from stakeout_agent.retention import RetentionPolicy

--- a/stakeout-agent/stakeout_agent/backends/postgres.py
+++ b/stakeout-agent/stakeout_agent/backends/postgres.py
@@ -9,6 +9,7 @@ import time
 from datetime import datetime, timezone
 
 from stakeout_agent.backends.base import AbstractMonitorDB, AbstractQueryDB
+from stakeout_agent.retention import RetentionPolicy
 
 _log = logging.getLogger(__name__)
 
@@ -92,9 +93,11 @@ def _percentile(values: list[float], p: int) -> float | None:
 
 
 class PostgresMonitorDB(AbstractMonitorDB, AbstractQueryDB):
-    def __init__(self):
+    def __init__(self, retention: RetentionPolicy | None = None):
         self._conn = None
         self._lock = threading.Lock()
+        self._retention = retention
+        self._run_expires: dict[str, datetime] = {}
 
     @property
     def _connection(self):
@@ -146,15 +149,20 @@ class PostgresMonitorDB(AbstractMonitorDB, AbstractQueryDB):
         run_inputs: str | None = None,
         parent_run_id: str | None = None,
         prompt_version: str | None = None,
+        environment: str | None = None,
     ) -> None:
+        exp_at = self._retention.expires_at(graph_id=graph_id, environment=environment) if self._retention else None
+        if exp_at is not None:
+            self._run_expires[run_id] = exp_at
+
         def _op():
             with self._connection.cursor() as cur:
                 cur.execute(
                     """
                     INSERT INTO runs
                         (run_id, graph_id, thread_id, status, started_at, ended_at, error,
-                         run_inputs, parent_run_id, prompt_version)
-                    VALUES (%s, %s, %s, 'running', %s, NULL, NULL, %s, %s, %s)
+                         run_inputs, parent_run_id, prompt_version, expires_at)
+                    VALUES (%s, %s, %s, 'running', %s, NULL, NULL, %s, %s, %s, %s)
                     """,
                     (
                         run_id,
@@ -164,6 +172,7 @@ class PostgresMonitorDB(AbstractMonitorDB, AbstractQueryDB):
                         run_inputs,
                         parent_run_id,
                         prompt_version,
+                        exp_at,
                     ),
                 )
             _log.debug("create_run inserted run_id=%s graph_id=%s", run_id, graph_id)
@@ -179,6 +188,8 @@ class PostgresMonitorDB(AbstractMonitorDB, AbstractQueryDB):
         total_cache_read_tokens: int | None = None,
         total_cache_creation_tokens: int | None = None,
     ) -> None:
+        self._run_expires.pop(run_id, None)
+
         def _op():
             with self._connection.cursor() as cur:
                 cur.execute(
@@ -207,6 +218,8 @@ class PostgresMonitorDB(AbstractMonitorDB, AbstractQueryDB):
         self._run_with_retry(f"complete_run {run_id}", _op)
 
     def fail_run(self, run_id: str, error: str) -> None:
+        self._run_expires.pop(run_id, None)
+
         def _op():
             with self._connection.cursor() as cur:
                 cur.execute(
@@ -219,6 +232,24 @@ class PostgresMonitorDB(AbstractMonitorDB, AbstractQueryDB):
                     _log.debug("fail_run run_id=%s", run_id)
 
         self._run_with_retry(f"fail_run {run_id}", _op)
+
+    def prune_runs(self, older_than_days: int) -> int:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=older_than_days)
+        deleted = 0
+
+        def _op():
+            nonlocal deleted
+            with self._connection.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM events WHERE run_id IN (SELECT run_id FROM runs WHERE started_at < %s)",
+                    (cutoff,),
+                )
+                cur.execute("DELETE FROM runs WHERE started_at < %s", (cutoff,))
+                deleted = cur.rowcount
+                _log.info("prune_runs deleted %d runs older than %d days", deleted, older_than_days)
+
+        self._run_with_retry(f"prune_runs older_than_days={older_than_days}", _op)
+        return deleted
 
     def insert_event(
         self,
@@ -238,6 +269,8 @@ class PostgresMonitorDB(AbstractMonitorDB, AbstractQueryDB):
         cache_read_tokens: int | None = None,
         cache_creation_tokens: int | None = None,
     ) -> None:
+        exp_at = self._run_expires.get(run_id)
+
         def _op():
             with self._connection.cursor() as cur:
                 cur.execute(
@@ -245,8 +278,8 @@ class PostgresMonitorDB(AbstractMonitorDB, AbstractQueryDB):
                     INSERT INTO events
                         (run_id, graph_id, event_type, node_name, latency_ms, payload, error,
                          messages, input_tokens, output_tokens, model, llm_input, llm_output,
-                         cache_read_tokens, cache_creation_tokens, timestamp)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                         cache_read_tokens, cache_creation_tokens, timestamp, expires_at)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     """,
                     (
                         run_id,
@@ -265,6 +298,7 @@ class PostgresMonitorDB(AbstractMonitorDB, AbstractQueryDB):
                         cache_read_tokens,
                         cache_creation_tokens,
                         datetime.now(timezone.utc),
+                        exp_at,
                     ),
                 )
             _log.debug("insert_event event_type=%s node=%s run_id=%s", event_type, node_name, run_id)

--- a/stakeout-agent/stakeout_agent/mcp/cli.py
+++ b/stakeout-agent/stakeout_agent/mcp/cli.py
@@ -48,6 +48,22 @@ def main() -> None:
     parser = argparse.ArgumentParser(prog="stakeout", description="stakeout-agent CLI")
     sub = parser.add_subparsers(dest="command", required=True)
 
+    retention_parser = sub.add_parser("retention", help="Manage data retention")
+    retention_sub = retention_parser.add_subparsers(dest="retention_command", required=True)
+
+    apply_parser = retention_sub.add_parser(
+        "apply", help="Delete runs and events whose expires_at has passed (Postgres only)"
+    )
+    apply_parser.add_argument("--log-level", default="WARNING", help="Logging level (default: WARNING)")
+
+    backfill_parser = retention_sub.add_parser(
+        "backfill", help="Backfill expires_at on existing rows using a default TTL"
+    )
+    backfill_parser.add_argument(
+        "--days", type=int, required=True, help="Set expires_at = started_at/timestamp + DAYS for rows missing it"
+    )
+    backfill_parser.add_argument("--log-level", default="WARNING", help="Logging level (default: WARNING)")
+
     mcp_parser = sub.add_parser("mcp", help="Start the MCP server")
     mcp_parser.add_argument(
         "--transport",
@@ -67,6 +83,99 @@ def main() -> None:
 
     if args.command == "mcp":
         _run_mcp(args)
+    elif args.command == "retention":
+        if args.retention_command == "apply":
+            _run_retention_apply(args)
+        elif args.retention_command == "backfill":
+            _run_retention_backfill(args)
+
+
+def _run_retention_apply(args: argparse.Namespace) -> None:
+    """Delete Postgres rows whose expires_at < NOW()."""
+    pg_uri = os.getenv("POSTGRES_URI") or os.getenv("DATABASE_URL")
+    if not pg_uri:
+        print("Error: POSTGRES_URI / DATABASE_URL must be set for 'retention apply'.", file=sys.stderr)
+        sys.exit(1)
+    try:
+        import psycopg2
+    except ImportError:
+        print("Error: psycopg2 is required. Run: pip install 'stakeout-agent[postgres]'", file=sys.stderr)
+        sys.exit(1)
+
+    conn = psycopg2.connect(pg_uri, connect_timeout=5)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM events WHERE expires_at IS NOT NULL AND expires_at < NOW()")
+        events_deleted = cur.rowcount
+        cur.execute("DELETE FROM runs WHERE expires_at IS NOT NULL AND expires_at < NOW()")
+        runs_deleted = cur.rowcount
+    conn.close()
+    print(f"retention apply: deleted {runs_deleted} run(s) and {events_deleted} event(s).")
+
+
+def _run_retention_backfill(args: argparse.Namespace) -> None:
+    """Backfill expires_at on existing rows that have none, using a fixed TTL in days."""
+    pg_uri = os.getenv("POSTGRES_URI") or os.getenv("DATABASE_URL")
+    mongo_uri = os.getenv("MONGO_URI")
+
+    if pg_uri:
+        try:
+            import psycopg2
+        except ImportError:
+            print("Error: psycopg2 is required. Run: pip install 'stakeout-agent[postgres]'", file=sys.stderr)
+            sys.exit(1)
+        conn = psycopg2.connect(pg_uri, connect_timeout=5)
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE runs   SET expires_at = started_at + INTERVAL '%s days' WHERE expires_at IS NULL",
+                (args.days,),
+            )
+            runs_updated = cur.rowcount
+            cur.execute(
+                "UPDATE events SET expires_at = timestamp   + INTERVAL '%s days' WHERE expires_at IS NULL",
+                (args.days,),
+            )
+            events_updated = cur.rowcount
+        conn.close()
+        print(f"retention backfill: updated {runs_updated} run(s) and {events_updated} event(s) (Postgres).")
+
+    elif mongo_uri:
+        try:
+            from pymongo import MongoClient
+        except ImportError:
+            print("Error: pymongo is required. Run: pip install 'stakeout-agent[mongodb]'", file=sys.stderr)
+            sys.exit(1)
+        from datetime import timedelta
+
+        db_name = os.getenv("MONGO_DB", "stakeout")
+        client = MongoClient(mongo_uri, serverSelectionTimeoutMS=5_000)
+        db = client[db_name]
+
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        delta = timedelta(days=args.days)
+
+        runs_result = db.runs.update_many(
+            {"expires_at": {"$exists": False}},
+            [{"$set": {"expires_at": {"$add": ["$started_at", int(delta.total_seconds() * 1000)]}}}],
+        )
+        events_result = db.events.update_many(
+            {"expires_at": {"$exists": False}},
+            [{"$set": {"expires_at": {"$add": ["$timestamp", int(delta.total_seconds() * 1000)]}}}],
+        )
+        client.close()
+        print(
+            f"retention backfill: updated {runs_result.modified_count} run(s)"
+            f" and {events_result.modified_count} event(s) (MongoDB)."
+        )
+    else:
+        print(
+            "Error: set MONGO_URI for MongoDB or POSTGRES_URI / DATABASE_URL for PostgreSQL.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 def _run_mcp(args: argparse.Namespace) -> None:

--- a/stakeout-agent/stakeout_agent/mcp/cli.py
+++ b/stakeout-agent/stakeout_agent/mcp/cli.py
@@ -152,9 +152,6 @@ def _run_retention_backfill(args: argparse.Namespace) -> None:
         client = MongoClient(mongo_uri, serverSelectionTimeoutMS=5_000)
         db = client[db_name]
 
-        from datetime import datetime, timezone
-
-        now = datetime.now(timezone.utc)
         delta = timedelta(days=args.days)
 
         runs_result = db.runs.update_many(

--- a/stakeout-agent/stakeout_agent/retention.py
+++ b/stakeout-agent/stakeout_agent/retention.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+
+@dataclass
+class RetentionPolicy:
+    """TTL-based data retention policy for stakeout backends.
+
+    Overrides are matched in priority order: environment first, then graph.
+    """
+
+    default_days: int
+    overrides: dict[str, int] = field(default_factory=dict)
+
+    def resolve(self, graph_id: str | None = None, environment: str | None = None) -> int:
+        """Return retention TTL in days for the given graph/environment."""
+        if environment is not None:
+            env_key = f"environment:{environment}"
+            if env_key in self.overrides:
+                return self.overrides[env_key]
+        if graph_id is not None:
+            graph_key = f"graph:{graph_id}"
+            if graph_key in self.overrides:
+                return self.overrides[graph_key]
+        return self.default_days
+
+    def expires_at(self, graph_id: str | None = None, environment: str | None = None) -> datetime:
+        """Return the absolute expiry datetime for a run starting now."""
+        days = self.resolve(graph_id=graph_id, environment=environment)
+        return datetime.now(timezone.utc) + timedelta(days=days)
+
+    @classmethod
+    def from_env(cls) -> RetentionPolicy | None:
+        """Construct a policy from STAKEOUT_RETENTION_* env vars, or None if unconfigured."""
+        default_raw = os.getenv("STAKEOUT_RETENTION_DEFAULT_DAYS")
+        if default_raw is None:
+            return None
+        overrides: dict[str, int] = {}
+        for env_name, key in (
+            ("STAKEOUT_RETENTION_DEV_DAYS", "environment:dev"),
+            ("STAKEOUT_RETENTION_STAGING_DAYS", "environment:staging"),
+        ):
+            raw = os.getenv(env_name)
+            if raw is not None:
+                overrides[key] = int(raw)
+        return cls(default_days=int(default_raw), overrides=overrides)

--- a/stakeout-agent/stakeout_agent/writer.py
+++ b/stakeout-agent/stakeout_agent/writer.py
@@ -109,6 +109,7 @@ class BufferedWriter(AbstractMonitorDB):
         run_inputs: str | None = None,
         parent_run_id: str | None = None,
         prompt_version: str | None = None,
+        environment: str | None = None,
     ) -> None:
         self._enqueue(
             "create_run",
@@ -118,6 +119,7 @@ class BufferedWriter(AbstractMonitorDB):
             run_inputs=run_inputs,
             parent_run_id=parent_run_id,
             prompt_version=prompt_version,
+            environment=environment,
         )
 
     def complete_run(
@@ -141,6 +143,9 @@ class BufferedWriter(AbstractMonitorDB):
 
     def fail_run(self, run_id: str, error: str) -> None:
         self._enqueue("fail_run", run_id, error)
+
+    def prune_runs(self, older_than_days: int) -> int:
+        return self._backend.prune_runs(older_than_days)
 
     def insert_event(
         self,

--- a/stakeout-agent/tests/test_buffered_writer.py
+++ b/stakeout-agent/tests/test_buffered_writer.py
@@ -81,7 +81,7 @@ class TestArgumentForwarding:
             writer.create_run("run-1", "my_graph", "thread-42", run_inputs="hi", prompt_version="v2")
 
         backend.create_run.assert_called_once_with(
-            "run-1", "my_graph", "thread-42", run_inputs="hi", parent_run_id=None, prompt_version="v2"
+            "run-1", "my_graph", "thread-42", run_inputs="hi", parent_run_id=None, prompt_version="v2", environment=None
         )
 
     def test_complete_run_forwards_token_args(self):

--- a/stakeout-agent/tests/test_retention.py
+++ b/stakeout-agent/tests/test_retention.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from stakeout_agent.retention import RetentionPolicy
+
+
+# ---------------------------------------------------------------------------
+# RetentionPolicy.resolve
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionPolicyResolve:
+    def test_default_ttl_when_no_overrides(self):
+        policy = RetentionPolicy(default_days=90)
+        assert policy.resolve() == 90
+
+    def test_default_ttl_when_no_match(self):
+        policy = RetentionPolicy(default_days=90, overrides={"environment:staging": 14})
+        assert policy.resolve(graph_id="other-graph", environment="prod") == 90
+
+    def test_override_by_environment(self):
+        policy = RetentionPolicy(default_days=90, overrides={"environment:dev": 7, "environment:staging": 14})
+        assert policy.resolve(environment="dev") == 7
+        assert policy.resolve(environment="staging") == 14
+
+    def test_override_by_graph(self):
+        policy = RetentionPolicy(default_days=90, overrides={"graph:experimental": 30})
+        assert policy.resolve(graph_id="experimental") == 30
+
+    def test_environment_takes_priority_over_graph(self):
+        policy = RetentionPolicy(
+            default_days=90,
+            overrides={"environment:dev": 7, "graph:experimental": 30},
+        )
+        assert policy.resolve(graph_id="experimental", environment="dev") == 7
+
+    def test_no_policy_leaves_expires_at_unset(self):
+        policy = None
+        # Simulate what backends do: no policy → no expires_at computed
+        exp = policy.expires_at() if policy else None
+        assert exp is None
+
+
+class TestRetentionPolicyExpiresAt:
+    def test_expires_at_is_in_future(self):
+        policy = RetentionPolicy(default_days=90)
+        before = datetime.now(timezone.utc)
+        exp = policy.expires_at()
+        after = datetime.now(timezone.utc)
+        assert before + timedelta(days=89) < exp < after + timedelta(days=91)
+
+    def test_expires_at_uses_resolved_days(self):
+        policy = RetentionPolicy(default_days=90, overrides={"environment:dev": 7})
+        exp = policy.expires_at(environment="dev")
+        expected_approx = datetime.now(timezone.utc) + timedelta(days=7)
+        assert abs((exp - expected_approx).total_seconds()) < 2
+
+
+class TestRetentionPolicyFromEnv:
+    def test_returns_none_when_env_not_set(self, monkeypatch):
+        monkeypatch.delenv("STAKEOUT_RETENTION_DEFAULT_DAYS", raising=False)
+        assert RetentionPolicy.from_env() is None
+
+    def test_reads_default_days_from_env(self, monkeypatch):
+        monkeypatch.setenv("STAKEOUT_RETENTION_DEFAULT_DAYS", "60")
+        monkeypatch.delenv("STAKEOUT_RETENTION_DEV_DAYS", raising=False)
+        monkeypatch.delenv("STAKEOUT_RETENTION_STAGING_DAYS", raising=False)
+        policy = RetentionPolicy.from_env()
+        assert policy is not None
+        assert policy.default_days == 60
+        assert policy.overrides == {}
+
+    def test_reads_environment_overrides_from_env(self, monkeypatch):
+        monkeypatch.setenv("STAKEOUT_RETENTION_DEFAULT_DAYS", "90")
+        monkeypatch.setenv("STAKEOUT_RETENTION_DEV_DAYS", "7")
+        monkeypatch.setenv("STAKEOUT_RETENTION_STAGING_DAYS", "14")
+        policy = RetentionPolicy.from_env()
+        assert policy is not None
+        assert policy.overrides["environment:dev"] == 7
+        assert policy.overrides["environment:staging"] == 14
+
+
+# ---------------------------------------------------------------------------
+# MongoDB backend: expires_at set on create_run / insert_event
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_mongo_db():
+    mock_runs = MagicMock()
+    mock_events = MagicMock()
+    result = MagicMock()
+    result.matched_count = 1
+    mock_runs.update_one.return_value = result
+    mock_db = MagicMock()
+    mock_db.runs = mock_runs
+    mock_db.events = mock_events
+    return mock_db, mock_runs, mock_events
+
+
+@contextmanager
+def _patched_mongo(mock_db, retention=None):
+    from stakeout_agent.backends.mongodb import MongoMonitorDB
+
+    with patch("stakeout_agent.backends.mongodb._make_client", return_value=mock_db):
+        yield MongoMonitorDB(retention=retention)
+
+
+class TestMongoRetention:
+    def test_no_retention_omits_expires_at(self):
+        mock_db, mock_runs, _ = _make_mock_mongo_db()
+        with _patched_mongo(mock_db, retention=None) as monitor:
+            monitor.create_run("r1", "my_graph", "t1")
+
+        doc = mock_runs.insert_one.call_args.args[0]
+        assert "expires_at" not in doc
+
+    def test_retention_sets_expires_at_on_create_run(self):
+        mock_db, mock_runs, _ = _make_mock_mongo_db()
+        policy = RetentionPolicy(default_days=30)
+        with _patched_mongo(mock_db, retention=policy) as monitor:
+            monitor.create_run("r1", "my_graph", "t1")
+
+        doc = mock_runs.insert_one.call_args.args[0]
+        assert isinstance(doc["expires_at"], datetime)
+        assert doc["expires_at"] > datetime.now(timezone.utc) + timedelta(days=29)
+
+    def test_retention_applies_environment_override(self):
+        mock_db, mock_runs, _ = _make_mock_mongo_db()
+        policy = RetentionPolicy(default_days=90, overrides={"environment:dev": 7})
+        with _patched_mongo(mock_db, retention=policy) as monitor:
+            monitor.create_run("r1", "my_graph", "t1", environment="dev")
+
+        doc = mock_runs.insert_one.call_args.args[0]
+        expected_approx = datetime.now(timezone.utc) + timedelta(days=7)
+        assert abs((doc["expires_at"] - expected_approx).total_seconds()) < 5
+
+    def test_retention_applies_graph_override(self):
+        mock_db, mock_runs, _ = _make_mock_mongo_db()
+        policy = RetentionPolicy(default_days=90, overrides={"graph:my_graph": 14})
+        with _patched_mongo(mock_db, retention=policy) as monitor:
+            monitor.create_run("r1", "my_graph", "t1")
+
+        doc = mock_runs.insert_one.call_args.args[0]
+        expected_approx = datetime.now(timezone.utc) + timedelta(days=14)
+        assert abs((doc["expires_at"] - expected_approx).total_seconds()) < 5
+
+    def test_event_inherits_expires_at_from_run(self):
+        mock_db, mock_runs, mock_events = _make_mock_mongo_db()
+        policy = RetentionPolicy(default_days=30)
+        with _patched_mongo(mock_db, retention=policy) as monitor:
+            monitor.create_run("r1", "my_graph", "t1")
+            monitor.insert_event(run_id="r1", graph_id="my_graph", event_type="node_start", node_name="n")
+
+        run_doc = mock_runs.insert_one.call_args.args[0]
+        event_doc = mock_events.insert_one.call_args.args[0]
+        assert event_doc["expires_at"] == run_doc["expires_at"]
+
+    def test_event_has_no_expires_at_without_retention(self):
+        mock_db, _, mock_events = _make_mock_mongo_db()
+        with _patched_mongo(mock_db, retention=None) as monitor:
+            monitor.create_run("r1", "my_graph", "t1")
+            monitor.insert_event(run_id="r1", graph_id="my_graph", event_type="node_start", node_name="n")
+
+        event_doc = mock_events.insert_one.call_args.args[0]
+        assert "expires_at" not in event_doc
+
+    def test_ttl_indexes_created_when_retention_configured(self):
+        mock_db, _, _ = _make_mock_mongo_db()
+        policy = RetentionPolicy(default_days=30)
+        with _patched_mongo(mock_db, retention=policy) as monitor:
+            _ = monitor._conn  # trigger lazy init
+
+        create_index_calls = mock_db.runs.create_index.call_args_list + mock_db.events.create_index.call_args_list
+        ttl_calls = [c for c in create_index_calls if c.kwargs.get("expireAfterSeconds") == 0]
+        assert len(ttl_calls) == 2
+
+    def test_no_ttl_indexes_without_retention(self):
+        mock_db, _, _ = _make_mock_mongo_db()
+        with _patched_mongo(mock_db, retention=None) as monitor:
+            _ = monitor._conn
+
+        create_index_calls = mock_db.runs.create_index.call_args_list + mock_db.events.create_index.call_args_list
+        ttl_calls = [c for c in create_index_calls if c.kwargs.get("expireAfterSeconds") == 0]
+        assert len(ttl_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Postgres backend: expires_at set on create_run / insert_event
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_pg_conn(rowcount: int = 1):
+    mock_cursor = MagicMock()
+    mock_cursor.rowcount = rowcount
+    mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_cursor.__exit__ = MagicMock(return_value=False)
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_conn.closed = 0
+    return mock_conn, mock_cursor
+
+
+@contextmanager
+def _patched_postgres(mock_conn, retention=None):
+    from stakeout_agent.backends.postgres import PostgresMonitorDB
+
+    with patch("stakeout_agent.backends.postgres._make_pg_conn", return_value=mock_conn):
+        yield PostgresMonitorDB(retention=retention)
+
+
+class TestPostgresRetention:
+    def test_no_retention_passes_null_expires_at(self):
+        mock_conn, mock_cursor = _make_mock_pg_conn()
+        with _patched_postgres(mock_conn, retention=None) as pg:
+            pg.create_run("r1", "my_graph", "t1")
+
+        sql, params = mock_cursor.execute.call_args.args
+        assert "expires_at" in sql
+        assert params[-1] is None  # expires_at is the last param
+
+    def test_retention_sets_expires_at_on_create_run(self):
+        mock_conn, mock_cursor = _make_mock_pg_conn()
+        policy = RetentionPolicy(default_days=30)
+        with _patched_postgres(mock_conn, retention=policy) as pg:
+            pg.create_run("r1", "my_graph", "t1")
+
+        _, params = mock_cursor.execute.call_args.args
+        exp_at = params[-1]
+        assert isinstance(exp_at, datetime)
+        assert exp_at > datetime.now(timezone.utc) + timedelta(days=29)
+
+    def test_retention_applies_environment_override(self):
+        mock_conn, mock_cursor = _make_mock_pg_conn()
+        policy = RetentionPolicy(default_days=90, overrides={"environment:dev": 7})
+        with _patched_postgres(mock_conn, retention=policy) as pg:
+            pg.create_run("r1", "my_graph", "t1", environment="dev")
+
+        _, params = mock_cursor.execute.call_args.args
+        exp_at = params[-1]
+        expected_approx = datetime.now(timezone.utc) + timedelta(days=7)
+        assert abs((exp_at - expected_approx).total_seconds()) < 5
+
+    def test_retention_applies_graph_override(self):
+        mock_conn, mock_cursor = _make_mock_pg_conn()
+        policy = RetentionPolicy(default_days=90, overrides={"graph:my_graph": 14})
+        with _patched_postgres(mock_conn, retention=policy) as pg:
+            pg.create_run("r1", "my_graph", "t1")
+
+        _, params = mock_cursor.execute.call_args.args
+        exp_at = params[-1]
+        expected_approx = datetime.now(timezone.utc) + timedelta(days=14)
+        assert abs((exp_at - expected_approx).total_seconds()) < 5
+
+    def test_event_inherits_expires_at_from_run(self):
+        mock_conn, mock_cursor = _make_mock_pg_conn()
+        policy = RetentionPolicy(default_days=30)
+        with _patched_postgres(mock_conn, retention=policy) as pg:
+            pg.create_run("r1", "my_graph", "t1")
+            run_params = mock_cursor.execute.call_args.args[1]
+            run_exp_at = run_params[-1]
+
+            pg.insert_event(run_id="r1", graph_id="my_graph", event_type="node_start", node_name="n")
+            event_params = mock_cursor.execute.call_args.args[1]
+            event_exp_at = event_params[-1]
+
+        assert event_exp_at == run_exp_at
+
+    def test_event_has_null_expires_at_without_retention(self):
+        mock_conn, mock_cursor = _make_mock_pg_conn()
+        with _patched_postgres(mock_conn, retention=None) as pg:
+            pg.create_run("r1", "my_graph", "t1")
+            pg.insert_event(run_id="r1", graph_id="my_graph", event_type="node_start", node_name="n")
+
+        event_params = mock_cursor.execute.call_args.args[1]
+        assert event_params[-1] is None  # expires_at

--- a/stakeout-agent/tests/test_retention.py
+++ b/stakeout-agent/tests/test_retention.py
@@ -4,10 +4,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from stakeout_agent.retention import RetentionPolicy
-
 
 # ---------------------------------------------------------------------------
 # RetentionPolicy.resolve


### PR DESCRIPTION
## Summary

Implements configurable TTL-based data retention policies (#63), enabling enterprises to automatically expire run data per project or environment for GDPR/CCPA compliance and storage cost control.

## Changes

### New: `RetentionPolicy` class (`stakeout_agent/retention.py`)
- `RetentionPolicy(default_days, overrides)` — overrides keyed by `"environment:<name>"` or `"graph:<id>"`, environment match takes priority over graph match
- `RetentionPolicy.from_env()` — reads `STAKEOUT_RETENTION_DEFAULT_DAYS`, `STAKEOUT_RETENTION_DEV_DAYS`, `STAKEOUT_RETENTION_STAGING_DAYS`
- Exported from `stakeout_agent` top-level

### MongoDB backend
- `MongoMonitorDB(retention=policy)` — optional retention policy, defaults to `None` (no change in behaviour)
- On first connect, creates TTL indexes on `runs.expires_at` and `events.expires_at` (`expireAfterSeconds=0`) when a policy is configured — MongoDB handles deletion with no background thread
- `create_run` computes `expires_at` at write time from the policy; events inherit the same expiry via an in-memory cache keyed by `run_id`

### PostgreSQL backend
- `PostgresMonitorDB(retention=policy)` — same opt-in pattern
- `create_run` and `insert_event` write `expires_at` into new columns
- Migration `0005_add_expires_at` adds `expires_at TIMESTAMPTZ` + partial indexes to both `runs` and `events`

### New CLI commands (`stakeout retention`)
- `stakeout retention apply` — deletes rows where `expires_at < NOW()` (for environments without `pg_cron`)
- `stakeout retention backfill --days N` — backfills `expires_at` on existing rows for both Postgres and MongoDB

### Other
- `AbstractMonitorDB.create_run` gains `environment: str | None = None` (backwards-compatible)
- `OTELMonitorDB` and `BufferedWriter` updated to satisfy the abstract interface (`prune_runs`, `environment` param)

## Usage

**Env vars:**
```bash
STAKEOUT_RETENTION_DEFAULT_DAYS=90
STAKEOUT_RETENTION_DEV_DAYS=7
STAKEOUT_RETENTION_STAGING_DAYS=14
