### PR TITLE
Closes #71

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,34 @@ One document per node/task start/end, tool call, or error.
 
 ---
 
+## Orphaned run cleanup
+
+A run that never reaches a terminal callback — a crashed process, an uncaught exception in a
+framework's internals, or a graph that hangs forever — would otherwise leak its in-memory state
+forever in a long-running service. Every callback handler and the `OTELMonitorDB` backend guard
+against this with an opportunistic **stale-run reaper**: on every new root-run start, entries
+older than a TTL are force-closed with a synthetic `StaleRunTimeout` failure (and, for OTEL,
+their span is ended with an `ERROR` status) so they don't accumulate.
+
+```python
+from stakeout_agent import LangGraphMonitorCallback
+
+monitor = LangGraphMonitorCallback(
+    graph_id="my_graph",
+    thread_id="thread_123",
+    stale_run_ttl_seconds=3600.0,  # default: 1 hour; pass None to disable
+)
+```
+
+`stale_run_ttl_seconds` (default `3600.0`) is accepted by all four callback variants —
+`LangGraphMonitorCallback`, `AsyncLangGraphMonitorCallback`, `CrewAIMonitorCallback`, and
+`AsyncCrewAIMonitorCallback`. `OTELMonitorDB` has the analogous `stale_span_ttl_seconds`
+(same default) for its in-memory span dicts. No legitimate invocation should run for an hour
+without emitting any node-level callback; raise the TTL (or pass `None`) if you have genuinely
+long-running graphs.
+
+---
+
 ## Error handling
 
 All database writes catch exceptions and log them — a monitoring failure will never crash your application. Enable `DEBUG` logging to see them:

--- a/stakeout-agent/README.md
+++ b/stakeout-agent/README.md
@@ -615,6 +615,34 @@ One document per node/task start/end, tool call, or error.
 
 ---
 
+## Orphaned run cleanup
+
+A run that never reaches a terminal callback — a crashed process, an uncaught exception in a
+framework's internals, or a graph that hangs forever — would otherwise leak its in-memory state
+forever in a long-running service. Every callback handler and the `OTELMonitorDB` backend guard
+against this with an opportunistic **stale-run reaper**: on every new root-run start, entries
+older than a TTL are force-closed with a synthetic `StaleRunTimeout` failure (and, for OTEL,
+their span is ended with an `ERROR` status) so they don't accumulate.
+
+```python
+from stakeout_agent import LangGraphMonitorCallback
+
+monitor = LangGraphMonitorCallback(
+    graph_id="my_graph",
+    thread_id="thread_123",
+    stale_run_ttl_seconds=3600.0,  # default: 1 hour; pass None to disable
+)
+```
+
+`stale_run_ttl_seconds` (default `3600.0`) is accepted by all four callback variants —
+`LangGraphMonitorCallback`, `AsyncLangGraphMonitorCallback`, `CrewAIMonitorCallback`, and
+`AsyncCrewAIMonitorCallback`. `OTELMonitorDB` has the analogous `stale_span_ttl_seconds`
+(same default) for its in-memory span dicts. No legitimate invocation should run for an hour
+without emitting any node-level callback; raise the TTL (or pass `None`) if you have genuinely
+long-running graphs.
+
+---
+
 ## Error handling
 
 All database writes catch exceptions and log them — a monitoring failure will never crash your application. Enable `DEBUG` logging to see them:

--- a/stakeout-agent/pyproject.toml
+++ b/stakeout-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "stakeout-agent"
-version = "0.2.2"
+version = "0.2.3"
 description = "Drop-in observability for LangGraph and CrewAI — captures every run, node, tool call, token count, prompt, and response into MongoDB, PostgreSQL, or any OpenTelemetry-compatible collector"
 readme = "README.md"
 license = { text = "MIT" }

--- a/stakeout-agent/stakeout_agent/backends/mongodb.py
+++ b/stakeout-agent/stakeout_agent/backends/mongodb.py
@@ -126,12 +126,22 @@ def _percentile(values: list[float], p: int) -> float | None:
     return statistics.quantiles(values, n=100)[p - 1]
 
 
+_STALE_EXPIRES_TTL_SECONDS = 86400.0  # 24h; _run_expires entries are tiny, so a long TTL is safe
+
+
 class MongoMonitorDB(AbstractMonitorDB, AbstractQueryDB):
     def __init__(self, retention: RetentionPolicy | None = None):
         self._db = None
         self._lock = threading.Lock()
         self._retention = retention
         self._run_expires: dict[str, datetime] = {}
+
+    def _reap_stale_expires(self, ttl_seconds: float = _STALE_EXPIRES_TTL_SECONDS) -> None:
+        """Drop _run_expires entries for runs that never called complete_run/fail_run."""
+        now = datetime.now(timezone.utc)
+        stale = [rid for rid, exp in self._run_expires.items() if (now - exp).total_seconds() > ttl_seconds]
+        for rid in stale:
+            self._run_expires.pop(rid, None)
 
     @property
     def _conn(self):
@@ -190,6 +200,7 @@ class MongoMonitorDB(AbstractMonitorDB, AbstractQueryDB):
         prompt_version: str | None = None,
         environment: str | None = None,
     ) -> None:
+        self._reap_stale_expires()
         exp_at = self._retention.expires_at(graph_id=graph_id, environment=environment) if self._retention else None
         if exp_at is not None:
             self._run_expires[run_id] = exp_at

--- a/stakeout-agent/stakeout_agent/backends/otel.py
+++ b/stakeout-agent/stakeout_agent/backends/otel.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import threading
+import time
 from typing import TYPE_CHECKING, Any
 
 from stakeout_agent.backends.base import AbstractMonitorDB
@@ -46,6 +47,7 @@ class OTELMonitorDB(AbstractMonitorDB):
         self,
         tracer_provider: TracerProvider | None = None,
         service_name: str | None = None,
+        stale_span_ttl_seconds: float | None = 3600.0,
     ) -> None:
         from opentelemetry import trace
 
@@ -60,10 +62,34 @@ class OTELMonitorDB(AbstractMonitorDB):
 
         self._tracer = self._provider.get_tracer(self.INSTRUMENTATION_NAME)
 
+        self._stale_span_ttl_seconds = stale_span_ttl_seconds
         self._lock = threading.Lock()
-        self._run_spans: dict[str, Span] = {}
-        self._node_spans: dict[tuple[str, str], Span] = {}
-        self._tool_spans: dict[tuple[str, str], Span] = {}
+        self._run_spans: dict[str, tuple[Span, float]] = {}
+        self._node_spans: dict[tuple[str, str], tuple[Span, float]] = {}
+        self._tool_spans: dict[tuple[str, str], tuple[Span, float]] = {}
+
+    def _reap_stale_spans(self, now: float) -> None:
+        """End and drop spans that have been open longer than the TTL.
+
+        Called from the top of create_run, so this leak cannot grow unbounded
+        between legitimate root-run invocations.
+        """
+        from opentelemetry.trace import StatusCode
+
+        if self._stale_span_ttl_seconds is None:
+            return
+        with self._lock:
+            for store, kind in (
+                (self._run_spans, "run"),
+                (self._node_spans, "node"),
+                (self._tool_spans, "tool"),
+            ):
+                stale_keys = [k for k, (_, start) in store.items() if now - start > self._stale_span_ttl_seconds]
+                for k in stale_keys:
+                    span, _ = store.pop(k)
+                    span.set_status(StatusCode.ERROR, description="StaleSpanTimeout")
+                    span.end()
+                    _logger.warning("otel: reaped stale %s span key=%s", kind, k)
 
     # ------------------------------------------------------------------
     # AbstractMonitorDB interface
@@ -79,6 +105,7 @@ class OTELMonitorDB(AbstractMonitorDB):
         prompt_version: str | None = None,
         environment: str | None = None,
     ) -> None:
+        self._reap_stale_spans(time.monotonic())
         attrs: dict[str, str] = {
             "stakeout.run_id": run_id,
             "stakeout.graph_id": graph_id,
@@ -92,7 +119,7 @@ class OTELMonitorDB(AbstractMonitorDB):
             attrs["stakeout.prompt_version"] = prompt_version
         span = self._tracer.start_span(graph_id, attributes=attrs)
         with self._lock:
-            self._run_spans[run_id] = span
+            self._run_spans[run_id] = (span, time.monotonic())
         _logger.debug("otel: root span started run_id=%s graph_id=%s", run_id, graph_id)
 
     def complete_run(
@@ -107,7 +134,8 @@ class OTELMonitorDB(AbstractMonitorDB):
         from opentelemetry.trace import StatusCode
 
         with self._lock:
-            span = self._run_spans.pop(run_id, None)
+            entry = self._run_spans.pop(run_id, None)
+        span = entry[0] if entry is not None else None
 
         if span is None:
             _logger.warning("otel: complete_run called for unknown run_id=%s", run_id)
@@ -135,7 +163,8 @@ class OTELMonitorDB(AbstractMonitorDB):
         from opentelemetry.trace import StatusCode
 
         with self._lock:
-            span = self._run_spans.pop(run_id, None)
+            entry = self._run_spans.pop(run_id, None)
+        span = entry[0] if entry is not None else None
 
         if span is None:
             _logger.warning("otel: fail_run called for unknown run_id=%s", run_id)
@@ -204,7 +233,8 @@ class OTELMonitorDB(AbstractMonitorDB):
         from opentelemetry import trace
 
         with self._lock:
-            root = self._run_spans.get(run_id)
+            entry = self._run_spans.get(run_id)
+        root = entry[0] if entry is not None else None
 
         if root is None:
             _logger.warning("otel: node_start for unknown run_id=%s node=%s", run_id, node_name)
@@ -216,7 +246,7 @@ class OTELMonitorDB(AbstractMonitorDB):
         span.set_attribute("stakeout.node_name", node_name)
 
         with self._lock:
-            self._node_spans[(run_id, node_name)] = span
+            self._node_spans[(run_id, node_name)] = (span, time.monotonic())
 
     def _on_node_end(
         self,
@@ -236,7 +266,8 @@ class OTELMonitorDB(AbstractMonitorDB):
         from opentelemetry.trace import StatusCode
 
         with self._lock:
-            span = self._node_spans.pop((run_id, node_name), None)
+            entry = self._node_spans.pop((run_id, node_name), None)
+        span = entry[0] if entry is not None else None
 
         if span is None:
             _logger.warning("otel: node_end for unknown span run_id=%s node=%s", run_id, node_name)
@@ -268,7 +299,8 @@ class OTELMonitorDB(AbstractMonitorDB):
         from opentelemetry import trace
 
         with self._lock:
-            root = self._run_spans.get(run_id)
+            entry = self._run_spans.get(run_id)
+        root = entry[0] if entry is not None else None
 
         if root is None:
             _logger.warning("otel: %s for unknown run_id=%s tool=%s", event_type, run_id, node_name)
@@ -280,7 +312,7 @@ class OTELMonitorDB(AbstractMonitorDB):
         span.set_attribute("stakeout.node_name", node_name)
 
         with self._lock:
-            self._tool_spans[(run_id, node_name)] = span
+            self._tool_spans[(run_id, node_name)] = (span, time.monotonic())
 
     def _on_tool_end(
         self,
@@ -294,7 +326,8 @@ class OTELMonitorDB(AbstractMonitorDB):
         from opentelemetry.trace import StatusCode
 
         with self._lock:
-            span = self._tool_spans.pop((run_id, node_name), None)
+            entry = self._tool_spans.pop((run_id, node_name), None)
+        span = entry[0] if entry is not None else None
 
         if span is None:
             _logger.warning("otel: %s for unknown span run_id=%s tool=%s", event_type, run_id, node_name)
@@ -311,7 +344,8 @@ class OTELMonitorDB(AbstractMonitorDB):
         from opentelemetry.trace import StatusCode
 
         with self._lock:
-            span = self._node_spans.pop((run_id, node_name), None) or self._tool_spans.pop((run_id, node_name), None)
+            entry = self._node_spans.pop((run_id, node_name), None) or self._tool_spans.pop((run_id, node_name), None)
+        span = entry[0] if entry is not None else None
 
         if span is None:
             _logger.warning("otel: error event for unknown span run_id=%s node=%s", run_id, node_name)

--- a/stakeout-agent/stakeout_agent/backends/postgres.py
+++ b/stakeout-agent/stakeout_agent/backends/postgres.py
@@ -92,12 +92,22 @@ def _percentile(values: list[float], p: int) -> float | None:
     return statistics.quantiles(values, n=100)[p - 1]
 
 
+_STALE_EXPIRES_TTL_SECONDS = 86400.0  # 24h; _run_expires entries are tiny, so a long TTL is safe
+
+
 class PostgresMonitorDB(AbstractMonitorDB, AbstractQueryDB):
     def __init__(self, retention: RetentionPolicy | None = None):
         self._conn = None
         self._lock = threading.Lock()
         self._retention = retention
         self._run_expires: dict[str, datetime] = {}
+
+    def _reap_stale_expires(self, ttl_seconds: float = _STALE_EXPIRES_TTL_SECONDS) -> None:
+        """Drop _run_expires entries for runs that never called complete_run/fail_run."""
+        now = datetime.now(timezone.utc)
+        stale = [rid for rid, exp in self._run_expires.items() if (now - exp).total_seconds() > ttl_seconds]
+        for rid in stale:
+            self._run_expires.pop(rid, None)
 
     @property
     def _connection(self):
@@ -151,6 +161,7 @@ class PostgresMonitorDB(AbstractMonitorDB, AbstractQueryDB):
         prompt_version: str | None = None,
         environment: str | None = None,
     ) -> None:
+        self._reap_stale_expires()
         exp_at = self._retention.expires_at(graph_id=graph_id, environment=environment) if self._retention else None
         if exp_at is not None:
             self._run_expires[run_id] = exp_at

--- a/stakeout-agent/stakeout_agent/callback_handler/base.py
+++ b/stakeout-agent/stakeout_agent/callback_handler/base.py
@@ -89,6 +89,7 @@ class _MonitorBase:
         parent_run_id: str | None = None,
         prompt_version: str | None = None,
         alert_manager: AlertManager | None = None,
+        stale_run_ttl_seconds: float | None = 3600.0,
     ):
         self.graph_id = graph_id
         self.thread_id = thread_id
@@ -104,6 +105,7 @@ class _MonitorBase:
         self.parent_run_id = parent_run_id
         self.prompt_version = prompt_version
         self._alert_manager = alert_manager
+        self._stale_run_ttl_seconds = stale_run_ttl_seconds
         self._log = logging.LoggerAdapter(_logger, {"graph_id": graph_id, "thread_id": thread_id})
 
         self._state_lock = threading.Lock()
@@ -112,6 +114,38 @@ class _MonitorBase:
         # any child event run_id str -> root run_id str, for routing child events to the right context
         self._run_id_to_root: dict[str, str] = {}
         self._dropped_events: int = 0
+
+    def _reap_stale_runs(self, now: float) -> None:
+        """Force-close root runs that have been active longer than the TTL.
+
+        Called from the top of every new root-run start, so the leak this guards
+        against cannot grow unbounded between legitimate invocations.
+        """
+        if self._stale_run_ttl_seconds is None:
+            return
+        with self._state_lock:
+            stale_ids = [
+                run_id
+                for run_id, ctx in self._active_runs.items()
+                if now - ctx.run_start_time > self._stale_run_ttl_seconds
+            ]
+        for run_id in stale_ids:
+            with self._state_lock:
+                ctx = self._active_runs.pop(run_id, None)
+                self._run_id_to_root.pop(run_id, None)
+                dangling = [rid for rid, root in self._run_id_to_root.items() if root == run_id]
+                for rid in dangling:
+                    self._run_id_to_root.pop(rid, None)
+            if ctx is not None:
+                self._log.warning(
+                    "reaping stale run_id=%s active for %.0fs (ttl=%.0fs) — writing synthetic timeout failure",
+                    run_id,
+                    now - ctx.run_start_time,
+                    self._stale_run_ttl_seconds,
+                )
+                self._safe_db_write(
+                    lambda rid=run_id: self.db.fail_run(rid, "StaleRunTimeout: no terminal event received")
+                )
 
     @property
     def dropped_events(self) -> int:
@@ -163,6 +197,7 @@ class _MonitorBase:
     ) -> None:
         run_id_str = str(run_id)
         if parent_run_id is None:
+            self._reap_stale_runs(time.monotonic())
             ctx = _RunContext(run_id=run_id_str)
             with self._state_lock:
                 self._active_runs[run_id_str] = ctx

--- a/stakeout-agent/stakeout_agent/callback_handler/crewai.py
+++ b/stakeout-agent/stakeout_agent/callback_handler/crewai.py
@@ -106,6 +106,7 @@ class CrewAIMonitorCallback(_MonitorBase, BaseEventListener):
         parent_run_id: str | None = None,
         prompt_version: str | None = None,
         alert_manager: AlertManager | None = None,
+        stale_run_ttl_seconds: float | None = 3600.0,
     ) -> None:
         if CrewKickoffStartedEvent is None:
             raise ImportError(
@@ -121,6 +122,7 @@ class CrewAIMonitorCallback(_MonitorBase, BaseEventListener):
             parent_run_id=parent_run_id,
             prompt_version=prompt_version,
             alert_manager=alert_manager,
+            stale_run_ttl_seconds=stale_run_ttl_seconds,
         )
         BaseEventListener.__init__(self)
 
@@ -131,6 +133,7 @@ class CrewAIMonitorCallback(_MonitorBase, BaseEventListener):
 
         @crewai_event_bus.on(CrewKickoffStartedEvent)
         def on_crew_start(source: Any, event: CrewKickoffStartedEvent) -> None:
+            self._reap_stale_runs(time.monotonic())
             run_id = str(uuid4())
             ctx = _RunContext(run_id=run_id)
             with self._state_lock:
@@ -377,6 +380,7 @@ class AsyncCrewAIMonitorCallback(_MonitorBase, BaseEventListener):
         parent_run_id: str | None = None,
         prompt_version: str | None = None,
         alert_manager: AlertManager | None = None,
+        stale_run_ttl_seconds: float | None = 3600.0,
     ) -> None:
         if CrewKickoffStartedEvent is None:
             raise ImportError(
@@ -393,6 +397,7 @@ class AsyncCrewAIMonitorCallback(_MonitorBase, BaseEventListener):
             parent_run_id=parent_run_id,
             prompt_version=prompt_version,
             alert_manager=alert_manager,
+            stale_run_ttl_seconds=stale_run_ttl_seconds,
         )
         BaseEventListener.__init__(self)
 
@@ -401,6 +406,7 @@ class AsyncCrewAIMonitorCallback(_MonitorBase, BaseEventListener):
 
         @crewai_event_bus.on(CrewKickoffStartedEvent)
         async def on_crew_start(source: Any, event: CrewKickoffStartedEvent) -> None:
+            self._reap_stale_runs(time.monotonic())
             run_id = str(uuid4())
             ctx = _RunContext(run_id=run_id)
             with self._state_lock:

--- a/stakeout-agent/stakeout_agent/callback_handler/langgraph.py
+++ b/stakeout-agent/stakeout_agent/callback_handler/langgraph.py
@@ -48,6 +48,7 @@ class LangGraphMonitorCallback(_MonitorBase, BaseCallbackHandler):
         parent_run_id: str | None = None,
         prompt_version: str | None = None,
         alert_manager: AlertManager | None = None,
+        stale_run_ttl_seconds: float | None = 3600.0,
     ):
         if LLMResult is None:
             raise ImportError(
@@ -66,6 +67,7 @@ class LangGraphMonitorCallback(_MonitorBase, BaseCallbackHandler):
             parent_run_id=parent_run_id,
             prompt_version=prompt_version,
             alert_manager=alert_manager,
+            stale_run_ttl_seconds=stale_run_ttl_seconds,
         )
         BaseCallbackHandler.__init__(self)
 
@@ -222,6 +224,7 @@ class AsyncLangGraphMonitorCallback(_MonitorBase, AsyncCallbackHandler):
         parent_run_id: str | None = None,
         prompt_version: str | None = None,
         alert_manager: AlertManager | None = None,
+        stale_run_ttl_seconds: float | None = 3600.0,
     ):
         if LLMResult is None:
             raise ImportError(
@@ -240,6 +243,7 @@ class AsyncLangGraphMonitorCallback(_MonitorBase, AsyncCallbackHandler):
             parent_run_id=parent_run_id,
             prompt_version=prompt_version,
             alert_manager=alert_manager,
+            stale_run_ttl_seconds=stale_run_ttl_seconds,
         )
         AsyncCallbackHandler.__init__(self)
 

--- a/stakeout-agent/tests/test_callback_handler.py
+++ b/stakeout-agent/tests/test_callback_handler.py
@@ -646,3 +646,74 @@ class TestLLMPayloadClearance:
         cb.on_chain_end({}, run_id=node_id, parent_run_id=root_id)
         cb.on_chain_end({}, run_id=root_id, parent_run_id=None)
         assert cb._active_runs == {}
+
+
+class TestStaleRunReaping:
+    def _make(self, **kwargs) -> tuple[LangGraphMonitorCallback, MagicMock]:
+        db = mock_db()
+        cb = LangGraphMonitorCallback(graph_id=GRAPH_ID, thread_id=THREAD_ID, db=db, **kwargs)
+        return cb, db
+
+    def test_stale_root_run_is_reaped_on_next_root_start(self, monkeypatch):
+        cb, db = self._make(stale_run_ttl_seconds=10.0)
+        stale_id = make_uuid()
+        cb.on_chain_start({}, {}, run_id=stale_id, parent_run_id=None)
+        db.reset_mock()
+
+        # Backdate the stale run's start time so it looks like it has been running
+        # far longer than the TTL, without needing to actually sleep in the test.
+        cb._active_runs[str(stale_id)].run_start_time = time.monotonic() - 100.0
+
+        new_id = make_uuid()
+        cb.on_chain_start({}, {}, run_id=new_id, parent_run_id=None)
+
+        db.fail_run.assert_called_once()
+        args, _ = db.fail_run.call_args
+        assert args[0] == str(stale_id)
+        assert "StaleRunTimeout" in args[1]
+        assert str(stale_id) not in cb._active_runs
+        assert str(stale_id) not in cb._run_id_to_root
+        assert str(new_id) in cb._active_runs
+
+    def test_dangling_child_run_ids_are_dropped_with_stale_root(self):
+        cb, db = self._make(stale_run_ttl_seconds=10.0)
+        stale_id = make_uuid()
+        child_id = make_uuid()
+        cb.on_chain_start({}, {}, run_id=stale_id, parent_run_id=None)
+        cb.on_chain_start({"name": "n"}, {}, run_id=child_id, parent_run_id=stale_id)
+        cb._active_runs[str(stale_id)].run_start_time = time.monotonic() - 100.0
+
+        cb.on_chain_start({}, {}, run_id=make_uuid(), parent_run_id=None)
+
+        assert str(child_id) not in cb._run_id_to_root
+
+    def test_run_within_ttl_is_not_reaped(self):
+        cb, db = self._make(stale_run_ttl_seconds=3600.0)
+        run_id = make_uuid()
+        cb.on_chain_start({}, {}, run_id=run_id, parent_run_id=None)
+        db.reset_mock()
+
+        cb.on_chain_start({}, {}, run_id=make_uuid(), parent_run_id=None)
+
+        db.fail_run.assert_not_called()
+        assert str(run_id) in cb._active_runs
+
+    def test_ttl_none_disables_reaping(self):
+        cb, db = self._make(stale_run_ttl_seconds=None)
+        stale_id = make_uuid()
+        cb.on_chain_start({}, {}, run_id=stale_id, parent_run_id=None)
+        cb._active_runs[str(stale_id)].run_start_time = time.monotonic() - 10_000.0
+        db.reset_mock()
+
+        cb.on_chain_start({}, {}, run_id=make_uuid(), parent_run_id=None)
+
+        db.fail_run.assert_not_called()
+        assert str(stale_id) in cb._active_runs
+
+    def test_normal_run_completing_within_ttl_leaves_no_leftover_state(self):
+        cb, db = self._make(stale_run_ttl_seconds=3600.0)
+        run_id = make_uuid()
+        cb.on_chain_start({}, {}, run_id=run_id, parent_run_id=None)
+        cb.on_chain_end({}, run_id=run_id, parent_run_id=None)
+        assert cb._active_runs == {}
+        assert cb._run_id_to_root == {}

--- a/stakeout-agent/tests/test_crewai_callback.py
+++ b/stakeout-agent/tests/test_crewai_callback.py
@@ -48,7 +48,7 @@ class MockBus:
             await self._handlers[event_type](source, event)
 
 
-def _make() -> tuple[CrewAIMonitorCallback, MagicMock, MockBus]:
+def _make(**kwargs) -> tuple[CrewAIMonitorCallback, MagicMock, MockBus]:
     db = MagicMock()
     bus = MockBus()
 
@@ -57,7 +57,7 @@ def _make() -> tuple[CrewAIMonitorCallback, MagicMock, MockBus]:
     original_bus = _mod.crewai_event_bus
     _mod.crewai_event_bus = bus
     try:
-        cb = CrewAIMonitorCallback(crew_id=CREW_ID, thread_id=THREAD_ID, db=db)
+        cb = CrewAIMonitorCallback(crew_id=CREW_ID, thread_id=THREAD_ID, db=db, **kwargs)
     finally:
         _mod.crewai_event_bus = original_bus
 
@@ -186,6 +186,47 @@ class TestCrewLifecycle:
         run_id = db.create_run.call_args.args[0]
         bus.emit(CrewKickoffFailedEvent, None, _crew_failed_event(error="Something went wrong"))
         db.fail_run.assert_called_once_with(run_id, "Something went wrong")
+
+
+class TestStaleRunReaping:
+    def test_stale_kickoff_is_reaped_on_next_kickoff_start(self):
+        cb, db, bus = _make(stale_run_ttl_seconds=10.0)
+        bus.emit(CrewKickoffStartedEvent, None, _crew_started_event())
+        stale_run_id = next(iter(cb._active_runs))
+        cb._active_runs[stale_run_id].run_start_time = time.monotonic() - 100.0
+        db.reset_mock()
+
+        bus.emit(CrewKickoffStartedEvent, None, _crew_started_event())
+
+        db.fail_run.assert_called_once()
+        args, _ = db.fail_run.call_args
+        assert args[0] == stale_run_id
+        assert "StaleRunTimeout" in args[1]
+        assert stale_run_id not in cb._active_runs
+        assert len(cb._active_runs) == 1
+
+    def test_run_within_ttl_is_not_reaped(self):
+        cb, db, bus = _make(stale_run_ttl_seconds=3600.0)
+        bus.emit(CrewKickoffStartedEvent, None, _crew_started_event())
+        run_id = next(iter(cb._active_runs))
+        db.reset_mock()
+
+        bus.emit(CrewKickoffStartedEvent, None, _crew_started_event())
+
+        db.fail_run.assert_not_called()
+        assert run_id in cb._active_runs
+
+    def test_ttl_none_disables_reaping(self):
+        cb, db, bus = _make(stale_run_ttl_seconds=None)
+        bus.emit(CrewKickoffStartedEvent, None, _crew_started_event())
+        stale_run_id = next(iter(cb._active_runs))
+        cb._active_runs[stale_run_id].run_start_time = time.monotonic() - 10_000.0
+        db.reset_mock()
+
+        bus.emit(CrewKickoffStartedEvent, None, _crew_started_event())
+
+        db.fail_run.assert_not_called()
+        assert stale_run_id in cb._active_runs
 
 
 # ---------------------------------------------------------------------------

--- a/stakeout-agent/tests/test_otel_backend.py
+++ b/stakeout-agent/tests/test_otel_backend.py
@@ -54,7 +54,7 @@ class TestCreateRun:
         provider, _, span = _make_mock_provider()
         db = _db(provider)
         db.create_run("run-1", "g", "t")
-        assert db._run_spans["run-1"] is span
+        assert db._run_spans["run-1"][0] is span
 
 
 # ---------------------------------------------------------------------------
@@ -384,3 +384,81 @@ class TestUnknownEventType:
     def test_unknown_event_type_does_not_raise(self):
         db = _db()
         db.insert_event(run_id="r", graph_id="g", event_type="custom_event", node_name="n")
+
+
+# ---------------------------------------------------------------------------
+# Stale span reaping
+# ---------------------------------------------------------------------------
+
+
+class TestStaleSpanReaping:
+    def test_stale_run_span_is_ended_with_error_on_next_create_run(self):
+        from opentelemetry.trace import StatusCode
+
+        provider, tracer, stale_span = _make_mock_provider()
+        db = OTELMonitorDB(tracer_provider=provider, stale_span_ttl_seconds=10.0)
+        db.create_run("stale-run", "g", "t")
+
+        run_id, (span, start) = next(iter(db._run_spans.items()))
+        db._run_spans[run_id] = (span, start - 100.0)
+
+        new_span = MagicMock()
+        tracer.start_span.return_value = new_span
+        db.create_run("new-run", "g", "t")
+
+        stale_span.set_status.assert_called_once()
+        assert stale_span.set_status.call_args.args[0] == StatusCode.ERROR
+        stale_span.end.assert_called_once()
+        assert "stale-run" not in db._run_spans
+        assert "new-run" in db._run_spans
+
+    def test_stale_node_and_tool_spans_are_ended(self):
+        provider, tracer, _ = _make_mock_provider()
+        db = OTELMonitorDB(tracer_provider=provider, stale_span_ttl_seconds=10.0)
+        db.create_run("run-1", "g", "t")
+
+        node_span = MagicMock()
+        tracer.start_span.return_value = node_span
+        db.insert_event(run_id="run-1", graph_id="g", event_type="node_start", node_name="my_node")
+
+        tool_span = MagicMock()
+        tracer.start_span.return_value = tool_span
+        db.insert_event(run_id="run-1", graph_id="g", event_type="tool_call", node_name="my_tool")
+
+        # backdate both child spans past the TTL
+        key = ("run-1", "my_node")
+        span, start = db._node_spans[key]
+        db._node_spans[key] = (span, start - 100.0)
+        key = ("run-1", "my_tool")
+        span, start = db._tool_spans[key]
+        db._tool_spans[key] = (span, start - 100.0)
+
+        db.create_run("run-2", "g", "t")
+
+        node_span.end.assert_called_once()
+        tool_span.end.assert_called_once()
+        assert ("run-1", "my_node") not in db._node_spans
+        assert ("run-1", "my_tool") not in db._tool_spans
+
+    def test_span_within_ttl_is_not_reaped(self):
+        provider, _, span = _make_mock_provider()
+        db = OTELMonitorDB(tracer_provider=provider, stale_span_ttl_seconds=3600.0)
+        db.create_run("run-1", "g", "t")
+
+        db.create_run("run-2", "g", "t")
+
+        span.end.assert_not_called()
+        assert "run-1" in db._run_spans
+
+    def test_ttl_none_disables_reaping(self):
+        provider, _, span = _make_mock_provider()
+        db = OTELMonitorDB(tracer_provider=provider, stale_span_ttl_seconds=None)
+        db.create_run("run-1", "g", "t")
+
+        run_id, (s, start) = next(iter(db._run_spans.items()))
+        db._run_spans[run_id] = (s, start - 10_000.0)
+
+        db.create_run("run-2", "g", "t")
+
+        span.end.assert_not_called()
+        assert "run-1" in db._run_spans

--- a/stakeout-agent/tests/test_retention.py
+++ b/stakeout-agent/tests/test_retention.py
@@ -275,3 +275,56 @@ class TestPostgresRetention:
 
         event_params = mock_cursor.execute.call_args.args[1]
         assert event_params[-1] is None  # expires_at
+
+
+# ---------------------------------------------------------------------------
+# _run_expires reaping (orphaned run/state memory leak cleanup)
+# ---------------------------------------------------------------------------
+
+
+class TestMongoReapStaleExpires:
+    def test_stale_entry_dropped_on_next_create_run(self):
+        mock_db, mock_runs, _ = _make_mock_mongo_db()
+        policy = RetentionPolicy(default_days=30)
+        with _patched_mongo(mock_db, retention=policy) as monitor:
+            monitor.create_run("stale-run", "my_graph", "t1")
+            monitor._run_expires["stale-run"] = datetime.now(timezone.utc) - timedelta(days=2)
+
+            monitor.create_run("new-run", "my_graph", "t1")
+
+            assert "stale-run" not in monitor._run_expires
+            assert "new-run" in monitor._run_expires
+
+    def test_entry_within_ttl_is_kept(self):
+        mock_db, mock_runs, _ = _make_mock_mongo_db()
+        policy = RetentionPolicy(default_days=30)
+        with _patched_mongo(mock_db, retention=policy) as monitor:
+            monitor.create_run("r1", "my_graph", "t1")
+            monitor.create_run("r2", "my_graph", "t1")
+
+            assert "r1" in monitor._run_expires
+            assert "r2" in monitor._run_expires
+
+
+class TestPostgresReapStaleExpires:
+    def test_stale_entry_dropped_on_next_create_run(self):
+        mock_conn, mock_cursor = _make_mock_pg_conn()
+        policy = RetentionPolicy(default_days=30)
+        with _patched_postgres(mock_conn, retention=policy) as pg:
+            pg.create_run("stale-run", "my_graph", "t1")
+            pg._run_expires["stale-run"] = datetime.now(timezone.utc) - timedelta(days=2)
+
+            pg.create_run("new-run", "my_graph", "t1")
+
+            assert "stale-run" not in pg._run_expires
+            assert "new-run" in pg._run_expires
+
+    def test_entry_within_ttl_is_kept(self):
+        mock_conn, mock_cursor = _make_mock_pg_conn()
+        policy = RetentionPolicy(default_days=30)
+        with _patched_postgres(mock_conn, retention=policy) as pg:
+            pg.create_run("r1", "my_graph", "t1")
+            pg.create_run("r2", "my_graph", "t1")
+
+            assert "r1" in pg._run_expires
+            assert "r2" in pg._run_expires

--- a/stakeout-agent/uv.lock
+++ b/stakeout-agent/uv.lock
@@ -4028,7 +4028,7 @@ wheels = [
 
 [[package]]
 name = "stakeout-agent"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Added stale_run_ttl_seconds (default 3600.0) constructor param and _reap_stale_runs(), called at the top of every new root-run start, force-closing runs whose _RunContext has outlived the TTL with a synthetic db.fail_run(..., "StaleRunTimeout: ..."), and cleaning up dangling _run_id_to_root entries.